### PR TITLE
Syncronized implementations of ConsoleTraceService for postgresql version 1.3.15 upgrade

### DIFF
--- a/src/Authorization/Altinn.Platform.Authorization.csproj
+++ b/src/Authorization/Altinn.Platform.Authorization.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     <PackageReference Include="Yuniql.AspNetCore" Version="1.2.25" />
-    <PackageReference Include="Yuniql.PostgreSql" Version="1.2.25" />
+    <PackageReference Include="Yuniql.PostgreSql" Version="1.3.15" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)'=='Debug'">

--- a/src/Authorization/Configuration/ConsoleTraceService.cs
+++ b/src/Authorization/Configuration/ConsoleTraceService.cs
@@ -10,41 +10,36 @@ namespace Altinn.Platform.Authorization.Configuration
     [ExcludeFromCodeCoverage]
     public class ConsoleTraceService : ITraceService
     {
-        /// <summary>
-        /// Debug enabled 
-        /// </summary>
+        /// <inheritdoc/>
         public bool IsDebugEnabled { get; set; } = false;
 
-        /// <inheritdoc/>>
+        /// <inheritdoc/>
         public bool IsTraceSensitiveData { get; set; } = false;
 
-        /// <inheritdoc/>>
-        public string TraceToDirectory { get; set; }
-
-        /// <inheritdoc/>>
+        /// <inheritdoc/>
         public bool IsTraceToFile { get; set; } = false;
 
-        /// <summary>
-        /// Info
-        /// </summary>      
+        /// <inheritdoc/>
+        public bool IsTraceToDirectory { get; set; } = false;
+
+        /// <inheritdoc/>
+        public string TraceDirectory { get; set; }
+
+        /// <inheritdoc/>
         public void Info(string message, object payload = null)
         {
             var traceMessage = $"INF   {DateTime.UtcNow.ToString("o")}   {message}{Environment.NewLine}";
             Console.Write(traceMessage);
         }
 
-        /// <summary>
-        /// Error
-        /// </summary>
+        /// <inheritdoc/>
         public void Error(string message, object payload = null)
         {
             var traceMessage = $"ERR   {DateTime.UtcNow.ToString("o")}   {message}{Environment.NewLine}";
             Console.Write(traceMessage);
         }
 
-        /// <summary>
-        /// Debug
-        /// </summary>
+        /// <inheritdoc/>
         public void Debug(string message, object payload = null)
         {
             if (IsDebugEnabled)
@@ -54,18 +49,14 @@ namespace Altinn.Platform.Authorization.Configuration
             }
         }
 
-        /// <summary>
-        /// Success
-        /// </summary>
+        /// <inheritdoc/>
         public void Success(string message, object payload = null)
         {
             var traceMessage = $"INF   {DateTime.UtcNow.ToString("u")}   {message}{Environment.NewLine}";
             Console.Write(traceMessage);
         }
 
-        /// <summary>
-        /// Warn
-        /// </summary>
+        /// <inheritdoc/>
         public void Warn(string message, object payload = null)
         {
             var traceMessage = $"WRN   {DateTime.UtcNow.ToString("o")}   {message}{Environment.NewLine}";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- updated for identical implementation of ConsoleTraceService across all repos owned by the authorization team
- upgraded altinn-authorization to Yuniql.PostgreSql version to 1.3.15

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
