### PR TITLE
Feature/266 delegation event replay api endpoint

### DIFF
--- a/src/Authorization/Controllers/DelegationsController.cs
+++ b/src/Authorization/Controllers/DelegationsController.cs
@@ -220,6 +220,41 @@ namespace Altinn.Platform.Authorization.Controllers
         }
 
         /// <summary>
+        /// Endpoint for triggering a replay of delegationchange events pushing them to the delegationevents queue for syncronization with Altinn 2.0
+        /// </summary>
+        /// <param name="startId">The first id in the range to replay</param>
+        /// <param name="endId">The last id in the range to replay. If left/set to 0 all events found after the startId will be replayed</param>
+        /// <response code="200">OK</response>
+        /// <response code="400">Bad Request</response>
+        /// <response code="500">Internal Server Error</response>
+        [HttpPost]
+        [Authorize(Policy = AuthzConstants.ALTINNII_AUTHORIZATION)]
+        [Route("authorization/api/v1/[controller]/delegationchangeevents/replay")]
+        public async Task<ActionResult> Post([FromQuery] int startId, [FromQuery] int endId)
+        {
+            if (startId <= 0)
+            {
+                ModelState.AddModelError("startId", $"Must specify a valid starting delegation change id for replay. Invalid value: {startId}");
+                return new ObjectResult(ProblemDetailsFactory.CreateValidationProblemDetails(HttpContext, ModelState));
+            }
+
+            if (endId != 0 && endId < startId)
+            {
+                ModelState.AddModelError("endId", $"The endId cannot be smaller than the startId. startId: {startId}, endId: {endId}");
+                return new ObjectResult(ProblemDetailsFactory.CreateValidationProblemDetails(HttpContext, ModelState));
+            }
+
+            bool result = await _pap.ReplayDelegationChangeEvents(startId, endId);
+
+            if (result)
+            {
+                return Ok();
+            }
+
+            return UnprocessableEntity();
+        }
+
+        /// <summary>
         /// Test method. Should be deleted?
         /// </summary>
         /// <returns>test string</returns>

--- a/src/Authorization/Migration/v0.07/01-setup-procedures.sql
+++ b/src/Authorization/Migration/v0.07/01-setup-procedures.sql
@@ -1,0 +1,27 @@
+-- Function: select_delegationchanges_by_id_range
+CREATE OR REPLACE FUNCTION delegation.select_delegationchanges_by_id_range(
+	_startid bigint,
+	_endid bigint DEFAULT '9223372036854775807'::bigint)
+    RETURNS SETOF delegation.delegationchanges 
+    LANGUAGE 'sql'
+    COST 100
+    STABLE PARALLEL SAFE 
+    ROWS 1000
+
+AS $BODY$
+
+  SELECT
+    delegationChangeId,
+    delegationChangeType,
+    altinnAppId, 
+    offeredByPartyId,
+    coveredByUserId,
+    coveredByPartyId,
+    performedByUserId,
+    blobStoragePolicyPath,
+    blobStorageVersionId,
+    created
+  FROM delegation.delegationChanges
+  WHERE
+    delegationChangeId BETWEEN _startId AND _endId
+$BODY$;

--- a/src/Authorization/Repositories/Interface/IDelegationMetadataRepository.cs
+++ b/src/Authorization/Repositories/Interface/IDelegationMetadataRepository.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.IO;
 using System.Threading.Tasks;
 using Altinn.Platform.Authorization.Models;
 
@@ -43,5 +42,13 @@ namespace Altinn.Platform.Authorization.Repositories.Interface
         /// <param name="coveredByPartyIds">The list of party id of the entity having received the delegated policy, if the entity is an organization</param>
         /// <param name="coveredByUserIds">The list of user id of the entity having received the delegated policy, if the entity is a user</param>
         Task<List<DelegationChange>> GetAllCurrentDelegationChanges(List<int> offeredByPartyIds, List<string> altinnAppIds = null, List<int> coveredByPartyIds = null, List<int> coveredByUserIds = null);
+
+        /// <summary>
+        /// Operation for getting delegationchange events by delegation change id range
+        /// </summary>
+        /// <param name="startId">The first id in the range to retrieve</param>
+        /// <param name="endId">The last id in the range to retrieve. If left to 0 all events after the startId will be returned</param>
+        /// <returns>List of delegation changes</returns>
+        Task<List<DelegationChange>> GetDelegationChangesByIdRange(int startId, int endId);
     }
 }

--- a/src/Authorization/Services/Interface/IPolicyAdministrationPoint.cs
+++ b/src/Authorization/Services/Interface/IPolicyAdministrationPoint.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Altinn.Platform.Authorization.Models;
+using Microsoft.AspNetCore.Mvc;
 
 namespace Altinn.Platform.Authorization.Services.Interface
 {
@@ -39,5 +40,13 @@ namespace Altinn.Platform.Authorization.Services.Interface
         /// <param name="policiesToDelete">entity containing match for all the policies to delete</param>
         /// <returns>A list containing all the policies that is deleted</returns>
         Task<List<Rule>> TryDeleteDelegationPolicies(List<RequestToDelete> policiesToDelete);
+
+        /// <summary>
+        /// Endpoint for triggering a replay of delegationchange events pushing them to the delegationevents queue for syncronization with Altinn 2.0
+        /// </summary>
+        /// <param name="startId">The first id in the range to replay</param>
+        /// <param name="endId">The last id in the range to replay. If left/set to 0 all events found after the startId will be replayed</param>
+        /// <returns>bool</returns>
+        Task<bool> ReplayDelegationChangeEvents([FromQuery] int startId, [FromQuery] int endId);
     }
 }

--- a/src/Authorization/Services/Interface/IPolicyAdministrationPoint.cs
+++ b/src/Authorization/Services/Interface/IPolicyAdministrationPoint.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Altinn.Platform.Authorization.Models;
-using Microsoft.AspNetCore.Mvc;
 
 namespace Altinn.Platform.Authorization.Services.Interface
 {
@@ -47,6 +46,6 @@ namespace Altinn.Platform.Authorization.Services.Interface
         /// <param name="startId">The first id in the range to replay</param>
         /// <param name="endId">The last id in the range to replay. If left/set to 0 all events found after the startId will be replayed</param>
         /// <returns>bool</returns>
-        Task<bool> ReplayDelegationChangeEvents([FromQuery] int startId, [FromQuery] int endId);
+        Task<bool> ReplayDelegationChangeEvents(int startId, int endId);
     }
 }

--- a/test/IntegrationTests/MockServices/DelegationMetadataRepositoryMock.cs
+++ b/test/IntegrationTests/MockServices/DelegationMetadataRepositoryMock.cs
@@ -155,5 +155,10 @@ namespace Altinn.Platform.Authorization.IntegrationTests.MockServices
 
             return Task.FromResult(result);
         }
+
+        public Task<List<DelegationChange>> GetDelegationChangesByIdRange(int startId, int endId)
+        {
+            throw new NotImplementedException();
+        }
     }
 }


### PR DESCRIPTION
## Description
- New postgres function for selecting delegationchanges by id-range to be replayed
- New API endpoint and service implementation

## Related Issue(s)
- #266

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
