### PR TITLE
Renaming of ssn and orgno party header values

### DIFF
--- a/src/Altinn.Common.PEP/Altinn.Common.PEP/Helpers/DecisionHelper.cs
+++ b/src/Altinn.Common.PEP/Altinn.Common.PEP/Helpers/DecisionHelper.cs
@@ -33,8 +33,8 @@ namespace Altinn.Common.PEP.Helpers
         private const string DefaultType = "string";
         private const string PersonHeaderTrigger = "person";
         private const string OrganizationHeaderTrigger = "organization";
-        private const string PersonHeader = "party-ssn";
-        private const string OrganizationNumberHeader = "party-organizationumber";
+        private const string PersonHeader = "Altinn-Party-SocialSecurityNumber";
+        private const string OrganizationNumberHeader = "Altinn-Party-OrganizationNumber";
 
         private const string PolicyObligationMinAuthnLevel = "urn:altinn:minimum-authenticationlevel";
         private const string PolicyObligationMinAuthnLevelOrg = "urn:altinn:minimum-authenticationlevel-org";

--- a/src/Altinn.Common.PEP/UnitTests/ResourceAccessHandlerTest.cs
+++ b/src/Altinn.Common.PEP/UnitTests/ResourceAccessHandlerTest.cs
@@ -161,12 +161,12 @@ namespace Altinn.Common.PEP.Authorization
             httpContext.Request.RouteValues.Add("party", party);
             if (!string.IsNullOrEmpty(orgHeader))
             {
-                httpContext.Request.Headers.Add("party-organizationumber", orgHeader);
+                httpContext.Request.Headers.Add("Altinn-Party-OrganizationNumber", orgHeader);
             }
             
             if (!string.IsNullOrEmpty(ssnHeader))
             {
-                httpContext.Request.Headers.Add("party-ssn", ssnHeader);
+                httpContext.Request.Headers.Add("Altinn-Party-SocialSecurityNumber", ssnHeader);
             }
 
             return httpContext;


### PR DESCRIPTION
## Description
Renamed:
"party-ssn" -> "Altinn-Party-SocialSecurityNumber"
"party-organizationumber" -> "Altinn-Party-OrganizationNumber"

## Related Issue(s)
- [#{issue number}](https://github.com/Altinn/altinn-access-management/issues/351)

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
