### PR TITLE
Fixed correct parsing of headers in PEP

### DIFF
--- a/src/Altinn.Common.PEP/Altinn.Common.PEP/Altinn.Common.PEP.csproj
+++ b/src/Altinn.Common.PEP/Altinn.Common.PEP/Altinn.Common.PEP.csproj
@@ -3,14 +3,14 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <AssemblyVersion>1.2.0.0</AssemblyVersion>
-    <FileVersion>1.2.0.0</FileVersion>
+    <AssemblyVersion>1.2.1.0</AssemblyVersion>
+    <FileVersion>1.2.1.0</FileVersion>
     <!-- SonarCloud needs this -->
     <ProjectGuid>{92f10f90-79c5-459f-8238-0ec4d02aa93c}</ProjectGuid>
     <IsPackable>true</IsPackable>
     <!-- NuGet package properties -->
     <PackageId>Altinn.Common.PEP</PackageId>
-    <PackageVersion>1.2.0</PackageVersion>
+    <PackageVersion>1.2.1</PackageVersion>
     <PackageTags>Altinn;Studio;Authorization;Policy;Enforcement;Point</PackageTags>
     <Description>
 		Policy Enforcement Point for Attribute-based authorization using Altinn.Authorization.ABAC in ASP.Net apps.

--- a/src/Altinn.Common.PEP/Altinn.Common.PEP/Helpers/DecisionHelper.cs
+++ b/src/Altinn.Common.PEP/Altinn.Common.PEP/Helpers/DecisionHelper.cs
@@ -236,11 +236,11 @@ namespace Altinn.Common.PEP.Helpers
             {
                 resourceCategory.Attribute.Add(CreateXacmlJsonAttribute(AltinnXacmlUrns.PartyId, partyId.Value.ToString(), DefaultType, DefaultIssuer, includeResult));
             }
-            else if (string.IsNullOrEmpty(organizationnumber))
+            else if (!string.IsNullOrEmpty(organizationnumber))
             {
                 resourceCategory.Attribute.Add(CreateXacmlJsonAttribute(AltinnXacmlUrns.OrganizationNumber, organizationnumber, DefaultType, DefaultIssuer, includeResult));
             }
-            else if (string.IsNullOrEmpty(ssn))
+            else if (!string.IsNullOrEmpty(ssn))
             {
                 resourceCategory.Attribute.Add(CreateXacmlJsonAttribute(AltinnXacmlUrns.Ssn, ssn, DefaultType, DefaultIssuer, includeResult));
             }

--- a/src/Altinn.Common.PEP/UnitTests/ResourceAccessHandlerTest.cs
+++ b/src/Altinn.Common.PEP/UnitTests/ResourceAccessHandlerTest.cs
@@ -73,6 +73,10 @@ namespace Altinn.Common.PEP.Authorization
             // Assert
             Assert.True(context.HasSucceeded);
             Assert.False(context.HasFailed);
+
+            XacmlJsonRequestRoot request = _pdpMock.Invocations[0].Arguments[0] as XacmlJsonRequestRoot;
+            Assert.Equal("urn:altinn:organizationnumber", request.Request.Resource[0].Attribute[0].AttributeId);
+            Assert.Equal("991825827", request.Request.Resource[0].Attribute[0].Value);
         }
 
         /// <summary>
@@ -117,6 +121,10 @@ namespace Altinn.Common.PEP.Authorization
             // Assert
             Assert.True(context.HasSucceeded);
             Assert.False(context.HasFailed);
+
+            XacmlJsonRequestRoot request = _pdpMock.Invocations[0].Arguments[0] as XacmlJsonRequestRoot;
+            Assert.Equal("urn:altinn:ssn", request.Request.Resource[0].Attribute[0].AttributeId);
+            Assert.Equal("01014922047", request.Request.Resource[0].Attribute[0].Value);
         }
 
         /// <summary>


### PR DESCRIPTION
Fix bug that did not set organizationnumber or ssn if that was given as header values. 

Improved test to verify this