### PR TITLE
Added support for using storage api for auth info

### DIFF
--- a/src/Authorization/Configuration/GeneralSettings.cs
+++ b/src/Authorization/Configuration/GeneralSettings.cs
@@ -71,5 +71,10 @@ namespace Altinn.Platform.Authorization.Configuration
                 return Environment.GetEnvironmentVariable("GeneralSettings__SBLBaseAdress") ?? SBLBaseAdress;
             }
         }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to use the storage component to get instance auth info
+        /// </summary>
+        public bool UseStorageApiForInstanceAuthInfo { get; set; }
     }
 }

--- a/src/Authorization/Configuration/PlatformSettings.cs
+++ b/src/Authorization/Configuration/PlatformSettings.cs
@@ -9,6 +9,11 @@ namespace Altinn.Platform.Authorization.Configuration
     public class PlatformSettings
     {
         /// <summary>
+        /// Gets or sets the url for the Storage API endpoint.
+        /// </summary>
+        public string ApiStorageEndpoint { get; set; }
+
+        /// <summary>
         /// Gets or sets the url for the Register API endpoint.
         /// </summary>
         public string ApiRegisterEndpoint { get; set; }

--- a/src/Authorization/Repositories/InstanceMetadataRepository.cs
+++ b/src/Authorization/Repositories/InstanceMetadataRepository.cs
@@ -37,6 +37,7 @@ namespace Altinn.Platform.Authorization.Repositories
         /// <param name="logger">the logger</param>
         /// <param name="storageClient">Storage client</param>
         /// <param name="platformSettings">Storage config</param>
+        /// <param name="generalSettings">General config to determine storage interface method</param>
         public InstanceMetadataRepository(IOptions<AzureCosmosSettings> cosmosettings, ILogger<InstanceMetadataRepository> logger, HttpClient storageClient, IOptions<PlatformSettings> platformSettings, IOptions<GeneralSettings> generalSettings)
         {
             this.logger = logger;

--- a/src/Authorization/Repositories/InstanceMetadataRepository.cs
+++ b/src/Authorization/Repositories/InstanceMetadataRepository.cs
@@ -1,5 +1,9 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Altinn.Platform.Authorization.Configuration;
 using Altinn.Platform.Authorization.Repositories.Interface;
@@ -23,13 +27,16 @@ namespace Altinn.Platform.Authorization.Repositories
         private readonly DocumentClient _client;
         private readonly AzureCosmosSettings _cosmosettings;
         private readonly ILogger<InstanceMetadataRepository> logger;
+        private readonly HttpClient _storageClient;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="InstanceMetadataRepository"/> class
         /// </summary>
         /// <param name="cosmosettings">the configuration settings for cosmos database</param>
         /// <param name="logger">the logger</param>
-        public InstanceMetadataRepository(IOptions<AzureCosmosSettings> cosmosettings, ILogger<InstanceMetadataRepository> logger)
+        /// <param name="storageClient">Storage client</param>
+        /// <param name="platformSettings">Storage config</param>
+        public InstanceMetadataRepository(IOptions<AzureCosmosSettings> cosmosettings, ILogger<InstanceMetadataRepository> logger, HttpClient storageClient, IOptions<PlatformSettings> platformSettings)
         {
             this.logger = logger;
 
@@ -48,6 +55,8 @@ namespace Altinn.Platform.Authorization.Repositories
             instanceCollectionId = _cosmosettings.InstanceCollection;
             applicationCollectionId = _cosmosettings.ApplicationCollection;
             _client.OpenAsync();
+            _storageClient = storageClient;
+            storageClient.BaseAddress = new Uri(platformSettings.Value.ApiStorageEndpoint);
         }
 
         /// <inheritdoc/>
@@ -59,6 +68,21 @@ namespace Altinn.Platform.Authorization.Repositories
             }
 
             return GetInstanceInternal(instanceId, instanceOwnerId);
+        }
+
+        /// <inheritdoc/>
+        public async Task<(ProcessState Process, string AppId)> GetAuthInfo(string instanceId)
+        {
+            HttpResponseMessage response = await _storageClient.GetAsync($"instances/AuthInfo/{instanceId}");
+            if (response.StatusCode == HttpStatusCode.OK)
+            {
+                string responseData = await response.Content.ReadAsStringAsync();
+                return Newtonsoft.Json.JsonConvert.DeserializeObject<(ProcessState Process, string AppId)>(responseData);
+            }
+            else
+            {
+                throw new Exception("Bad response: " + response.StatusCode);
+            }
         }
 
         /// <inheritdoc/>

--- a/src/Authorization/Repositories/Interface/IInstanceMetadataRepository.cs
+++ b/src/Authorization/Repositories/Interface/IInstanceMetadataRepository.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Altinn.Platform.Storage.Interface.Models;
 
@@ -8,6 +9,13 @@ namespace Altinn.Platform.Authorization.Repositories.Interface
     /// </summary>
     public interface IInstanceMetadataRepository
     {
+        /// <summary>
+        /// Gets auth info for a process
+        /// </summary>
+        /// <param name="instanceId">the instance id</param>
+        /// <returns>Auth info</returns>
+        Task<(ProcessState Process, string AppId)> GetAuthInfo(string instanceId);
+
         /// <summary>
         /// Gets the information of a given instance
         /// </summary>

--- a/src/Authorization/Services/Implementation/ContextHandler.cs
+++ b/src/Authorization/Services/Implementation/ContextHandler.cs
@@ -91,7 +91,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                 {
                     instanceData = new();
                     (instanceData.Process, instanceData.AppId) = await _policyInformationRepository.GetAuthInfo(resourceAttributes.InstanceValue);
-                    instanceData.Org = instanceData.AppId.Split('/').First();
+                    instanceData.Org = instanceData.AppId.Split('/')[0];
                 }
 
                 if (instanceData != null)
@@ -108,7 +108,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                         AddIfValueDoesNotExist(resourceContextAttributes, XacmlRequestAttribute.EndEventAttribute, null, instanceData.Process.EndEvent);
                     }
 
-                    string partyId = resourceAttributes.InstanceValue.Split('/').First();
+                    string partyId = resourceAttributes.InstanceValue.Split('/')[0];
                     AddIfValueDoesNotExist(resourceContextAttributes, XacmlRequestAttribute.PartyAttribute, resourceAttributes.ResourcePartyValue, partyId);
                     resourceAttributes.ResourcePartyValue = partyId;
                 }

--- a/src/Authorization/Services/Implementation/ContextHandler.cs
+++ b/src/Authorization/Services/Implementation/ContextHandler.cs
@@ -82,7 +82,18 @@ namespace Altinn.Platform.Authorization.Services.Implementation
 
             if (!resourceAttributeComplete && !string.IsNullOrEmpty(resourceAttributes.InstanceValue))
             {
-                Instance instanceData = await _policyInformationRepository.GetInstance(resourceAttributes.InstanceValue);
+                Instance instanceData = null;
+                if (!_generalSettings.UseStorageApiForInstanceAuthInfo)
+                {
+                    instanceData = await _policyInformationRepository.GetInstance(resourceAttributes.InstanceValue);
+                }
+                else
+                {
+                    instanceData = new();
+                    (instanceData.Process, instanceData.AppId) = await _policyInformationRepository.GetAuthInfo(resourceAttributes.InstanceValue);
+                    instanceData.Org = instanceData.AppId.Split('/').First();
+                }
+
                 if (instanceData != null)
                 {
                     AddIfValueDoesNotExist(resourceContextAttributes, XacmlRequestAttribute.OrgAttribute, resourceAttributes.OrgValue, instanceData.Org);
@@ -97,8 +108,9 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                         AddIfValueDoesNotExist(resourceContextAttributes, XacmlRequestAttribute.EndEventAttribute, null, instanceData.Process.EndEvent);
                     }
 
-                    AddIfValueDoesNotExist(resourceContextAttributes, XacmlRequestAttribute.PartyAttribute, resourceAttributes.ResourcePartyValue, instanceData.InstanceOwner.PartyId);
-                    resourceAttributes.ResourcePartyValue = instanceData.InstanceOwner.PartyId;
+                    string partyId = resourceAttributes.InstanceValue.Split('/').First();
+                    AddIfValueDoesNotExist(resourceContextAttributes, XacmlRequestAttribute.PartyAttribute, resourceAttributes.ResourcePartyValue, partyId);
+                    resourceAttributes.ResourcePartyValue = partyId;
                 }
             }
 

--- a/src/Authorization/appsettings.json
+++ b/src/Authorization/appsettings.json
@@ -1,21 +1,21 @@
 {
   "AzureStorageConfiguration": {
-    "MetadataAccountName": "devstoreaccount1",
-    "MetadataAccountKey": "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==",
+    "MetadataAccountName": "altinnyt01storage01",
+    "MetadataAccountKey": "CMnzaw5a2M2kdlHBRXLdx1+HbEUjrEnZ7rh+EykAe/pTFVmcu9AicY1tS7nPzfWYJx52hh23Vmjh6A4i9hJAtA==",
     "MetadataContainer": "metadata",
-    "MetadataBlobEndpoint": "http://127.0.0.1:10000/devstoreaccount1",
-    "DelegationsAccountName": "devstoreaccount1",
-    "DelegationsAccountKey": "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==",
+    "MetadataBlobEndpoint": "https://altinnyt01storage01.blob.core.windows.net/",
+    "DelegationsAccountName": "altinnyt01storage03",
+    "DelegationsAccountKey": "3kt4DB6x8ymbAOPCgJTlynmmdWybjt/qrI6BO6LL/XiEAt5ps7SJ6w30bMmgvVBr0YTLZm6/y6IKPvQ+oPeBrw==",
     "DelegationsContainer": "delegationpolicies",
-    "DelegationsBlobEndpoint": "http://127.0.0.1:10000/devstoreaccount1",
+    "DelegationsBlobEndpoint": "https://altinnyt01storage03.blob.core.windows.net/",
     "BlobLeaseTimeout": 15,
-    "DelegationEventQueueEndpoint": "http://127.0.0.1:10000/devstoreaccount1",
-    "DelegationEventQueueAccountName": "devstoreaccount1",
-    "DelegationEventQueueAccountKey": "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
+    "DelegationEventQueueEndpoint": "https://altinnyt01storage04.queue.core.windows.net/",
+    "DelegationEventQueueAccountName": "altinnyt01storage01",
+    "DelegationEventQueueAccountKey": "yRcX21IA0h983P49MVi0Nb87GjwITcj9+4/hoXykRkO+p3/AAWmGqcjfb/0iuNUbJU8vgsKExOVZSHBahb5ong=="
   },
   "AzureCosmosSettings": {
-    "EndpointUri": "https://localhost:8081",
-    "PrimaryKey": "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==",
+    "EndpointUri": "https://altinn-yt01-cosmos-db.documents.azure.com:443/",
+    "PrimaryKey": "H8tRcYF7vG56TKyYDlxQS5PKwSCsBEdRDMhhSHurjtmOTBPCCW2Z8ZZpoJOrYgl3FLAqnRQ4NmKBw4ByRnRyKQ==",
     "Database": "Storage",
     "InstanceCollection": "instances",
     "ApplicationCollection": "applications"
@@ -23,23 +23,34 @@
   "PostgreSQLSettings": {
     "EnableDBConnection": "true",
     "WorkspacePath": "Migration",
-    "AdminConnectionString": "Host=localhost;Port=5432;Username=platform_authorization_admin;Password={0};Database=authorizationdb",
-    "ConnectionString": "Host=localhost;Port=5432;Username=platform_authorization;Password={0};Database=authorizationdb",
-    "AuthorizationDbAdminPwd": "Password",
-    "AuthorizationDbPwd": "Password"
+    "AdminConnectionString": "Host=altinn-authorization-db-yt01-pgflex.postgres.database.azure.com;Port=5432;Username=platform_authorization_admin;Password={0};Database=authorizationdb;SslMode=Require;TrustServerCertificate=true",
+    "ConnectionString": "Host=altinn-authorization-db-yt01-pgflex.postgres.database.azure.com;Port=5432;Username=platform_authorization;Password={0};Database=authorizationdb;SslMode=Require;TrustServerCertificate=true",
+    "AuthorizationDbAdminPwd": "WFniAIDlPyu23TV",
+    "AuthorizationDbPwd": "VFYkNeXSxp7TVIP"
   },
   "GeneralSettings": {
-    "OpenIdWellKnownEndpoint": "https://platform.at22.altinn.cloud/authentication/api/v1/openid/",
-    "BridgeApiEndpoint": "https://at22.altinn.cloud/sblbridge/authorization/api/",
+    "OpenIdWellKnownEndpoint": "https://platform.yt01.altinn.cloud/authentication/api/v1/openid/",
+    "BridgeApiEndpoint": "http://devenv.altinn.no:88/sblbridge/authorization/api/",
+    "_BridgeApiEndpoint_": "https://yt01.ai.basefarm.net/sblbridge/authorization/api/",
+    "__BridgeApiEndpoint__": "https://ai-yt01-vip-sblbridge.ai.basefarm.net/sblbridge/authorization/api/",
     "RuntimeCookieName": "AltinnStudioRuntime",
-    "SBLBaseAdress": "https://at22.altinn.cloud/",
+    "SBLBaseAdress": "http://devenv.altinn.no/",
     "RoleCacheTimeout": 5,
     "MainUnitCacheTimeout": 5,
     "KeyrolePartyIdsCacheTimeout": 5,
-    "PolicyCacheTimeout": 10
+    "PolicyCacheTimeout": 10,
+    "UseStorageApiForInstanceAuthInfo": true
   },
   "PlatformSettings": {
     "ApiRegisterEndpoint": "http://localhost:5101/register/api/v1/",
+    "ApiStorageEndpoint": "http://localhost:5010/storage/api/v1/",
     "ApiResourceRegistryEndpoint": "http://localhost:5101/resourceregistry/api/v1/"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Error",
+      "System": "Error",
+      "Microsoft": "Error"
+    }
   }
 }

--- a/src/Authorization/appsettings.json
+++ b/src/Authorization/appsettings.json
@@ -1,21 +1,21 @@
 {
   "AzureStorageConfiguration": {
-    "MetadataAccountName": "altinnyt01storage01",
-    "MetadataAccountKey": "CMnzaw5a2M2kdlHBRXLdx1+HbEUjrEnZ7rh+EykAe/pTFVmcu9AicY1tS7nPzfWYJx52hh23Vmjh6A4i9hJAtA==",
+    "MetadataAccountName": "devstoreaccount1",
+    "MetadataAccountKey": "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==",
     "MetadataContainer": "metadata",
-    "MetadataBlobEndpoint": "https://altinnyt01storage01.blob.core.windows.net/",
-    "DelegationsAccountName": "altinnyt01storage03",
-    "DelegationsAccountKey": "3kt4DB6x8ymbAOPCgJTlynmmdWybjt/qrI6BO6LL/XiEAt5ps7SJ6w30bMmgvVBr0YTLZm6/y6IKPvQ+oPeBrw==",
+    "MetadataBlobEndpoint": "http://127.0.0.1:10000/devstoreaccount1",
+    "DelegationsAccountName": "devstoreaccount1",
+    "DelegationsAccountKey": "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==",
     "DelegationsContainer": "delegationpolicies",
-    "DelegationsBlobEndpoint": "https://altinnyt01storage03.blob.core.windows.net/",
+    "DelegationsBlobEndpoint": "http://127.0.0.1:10000/devstoreaccount1",
     "BlobLeaseTimeout": 15,
-    "DelegationEventQueueEndpoint": "https://altinnyt01storage04.queue.core.windows.net/",
-    "DelegationEventQueueAccountName": "altinnyt01storage01",
-    "DelegationEventQueueAccountKey": "yRcX21IA0h983P49MVi0Nb87GjwITcj9+4/hoXykRkO+p3/AAWmGqcjfb/0iuNUbJU8vgsKExOVZSHBahb5ong=="
+    "DelegationEventQueueEndpoint": "http://127.0.0.1:10000/devstoreaccount1",
+    "DelegationEventQueueAccountName": "devstoreaccount1",
+    "DelegationEventQueueAccountKey": "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
   },
   "AzureCosmosSettings": {
-    "EndpointUri": "https://altinn-yt01-cosmos-db.documents.azure.com:443/",
-    "PrimaryKey": "H8tRcYF7vG56TKyYDlxQS5PKwSCsBEdRDMhhSHurjtmOTBPCCW2Z8ZZpoJOrYgl3FLAqnRQ4NmKBw4ByRnRyKQ==",
+    "EndpointUri": "https://localhost:8081",
+    "PrimaryKey": "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==",
     "Database": "Storage",
     "InstanceCollection": "instances",
     "ApplicationCollection": "applications"
@@ -23,18 +23,16 @@
   "PostgreSQLSettings": {
     "EnableDBConnection": "true",
     "WorkspacePath": "Migration",
-    "AdminConnectionString": "Host=altinn-authorization-db-yt01-pgflex.postgres.database.azure.com;Port=5432;Username=platform_authorization_admin;Password={0};Database=authorizationdb;SslMode=Require;TrustServerCertificate=true",
-    "ConnectionString": "Host=altinn-authorization-db-yt01-pgflex.postgres.database.azure.com;Port=5432;Username=platform_authorization;Password={0};Database=authorizationdb;SslMode=Require;TrustServerCertificate=true",
-    "AuthorizationDbAdminPwd": "WFniAIDlPyu23TV",
-    "AuthorizationDbPwd": "VFYkNeXSxp7TVIP"
+    "AdminConnectionString": "Host=localhost;Port=5432;Username=platform_authorization_admin;Password={0};Database=authorizationdb",
+    "ConnectionString": "Host=localhost;Port=5432;Username=platform_authorization;Password={0};Database=authorizationdb",
+    "AuthorizationDbAdminPwd": "Password",
+    "AuthorizationDbPwd": "Password"
   },
   "GeneralSettings": {
-    "OpenIdWellKnownEndpoint": "https://platform.yt01.altinn.cloud/authentication/api/v1/openid/",
-    "BridgeApiEndpoint": "http://devenv.altinn.no:88/sblbridge/authorization/api/",
-    "_BridgeApiEndpoint_": "https://yt01.ai.basefarm.net/sblbridge/authorization/api/",
-    "__BridgeApiEndpoint__": "https://ai-yt01-vip-sblbridge.ai.basefarm.net/sblbridge/authorization/api/",
+    "OpenIdWellKnownEndpoint": "https://platform.at22.altinn.cloud/authentication/api/v1/openid/",
+    "BridgeApiEndpoint": "https://at22.altinn.cloud/sblbridge/authorization/api/",
     "RuntimeCookieName": "AltinnStudioRuntime",
-    "SBLBaseAdress": "http://devenv.altinn.no/",
+    "SBLBaseAdress": "https://at22.altinn.cloud/",
     "RoleCacheTimeout": 5,
     "MainUnitCacheTimeout": 5,
     "KeyrolePartyIdsCacheTimeout": 5,
@@ -45,12 +43,5 @@
     "ApiRegisterEndpoint": "http://localhost:5101/register/api/v1/",
     "ApiStorageEndpoint": "http://localhost:5010/storage/api/v1/",
     "ApiResourceRegistryEndpoint": "http://localhost:5101/resourceregistry/api/v1/"
-  },
-  "Logging": {
-    "LogLevel": {
-      "Default": "Error",
-      "System": "Error",
-      "Microsoft": "Error"
-    }
   }
 }

--- a/src/Authorization/appsettings.json
+++ b/src/Authorization/appsettings.json
@@ -37,7 +37,7 @@
     "MainUnitCacheTimeout": 5,
     "KeyrolePartyIdsCacheTimeout": 5,
     "PolicyCacheTimeout": 10,
-    "UseStorageApiForInstanceAuthInfo": true
+    "UseStorageApiForInstanceAuthInfo": false
   },
   "PlatformSettings": {
     "ApiRegisterEndpoint": "http://localhost:5101/register/api/v1/",

--- a/test/IntegrationTests/MockServices/InstanceMetadataRepositoryMock.cs
+++ b/test/IntegrationTests/MockServices/InstanceMetadataRepositoryMock.cs
@@ -57,5 +57,10 @@ namespace Altinn.Platform.Authorization.IntegrationTests.MockServices
             Instance instance = (Instance)JsonConvert.DeserializeObject(content, typeof(Instance));
             return instance;
         }
+
+        Task<(ProcessState Process, string AppId)> IInstanceMetadataRepository.GetAuthInfo(string instanceId)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/test/IntegrationTests/PolicyInformationRepositoryTest.cs
+++ b/test/IntegrationTests/PolicyInformationRepositoryTest.cs
@@ -60,7 +60,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests
                 connectionPolicy);
             _client.OpenAsync();
 
-            _pir = new InstanceMetadataRepository(_dbConfigMock.Object, new Mock<ILogger<InstanceMetadataRepository>>().Object);
+            _pir = new InstanceMetadataRepository(_dbConfigMock.Object, new Mock<ILogger<InstanceMetadataRepository>>().Object, null, null);
         }
 
         /// <summary>

--- a/test/IntegrationTests/PolicyInformationRepositoryTest.cs
+++ b/test/IntegrationTests/PolicyInformationRepositoryTest.cs
@@ -60,7 +60,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests
                 connectionPolicy);
             _client.OpenAsync();
 
-            _pir = new InstanceMetadataRepository(_dbConfigMock.Object, new Mock<ILogger<InstanceMetadataRepository>>().Object, null, null);
+            _pir = new InstanceMetadataRepository(_dbConfigMock.Object, new Mock<ILogger<InstanceMetadataRepository>>().Object, null, null, Options.Create(new GeneralSettings() { UseStorageApiForInstanceAuthInfo = false }));
         }
 
         /// <summary>

--- a/test/IntegrationTests/appsettings.json
+++ b/test/IntegrationTests/appsettings.json
@@ -26,11 +26,13 @@
   "GeneralSettings": {
     "OpenIdWellKnownEndpoint": "http://localhost:5040/authentication/api/v1/openid/",
     "BridgeApiEndpoint": "https://at22.altinn.cloud/sblbridge/authorization/api/",
+    "ApiStorageEndpoint": "http://localhost:5010/storage/api/v1/",
     "RuntimeCookieName": "AltinnStudioRuntime",
     "SBLBaseAdress": "https://at22.altinn.cloud/",
     "RoleCacheTimeout": 5,
     "MainUnitCacheTimeout": 5,
     "KeyrolePartyIdsCacheTimeout": 5,
-    "PolicyCacheTimeout": 10
+    "PolicyCacheTimeout": 10,
+    "UseStorageApiForInstanceAuthInfo": false
   }
 }


### PR DESCRIPTION
## Description
Storage is currently changing the storage database from Cosmos to PostgreSQL. This PR uses a new API to get auth info from storage rather than getting the data from the database without using a Storage API.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
