### PR TITLE
Bumping Microsoft.Extensions.Http dependency to 7.0.0 to match version depencies

### DIFF
--- a/src/Functions/Altinn.Platform.Authorization.Functions.csproj
+++ b/src/Functions/Altinn.Platform.Authorization.Functions.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.1.3" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.2-mauipre.1.22102.15" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.2.0" />
     <PackageReference Include="Altinn.Common.AccessTokenClient" Version="1.1.4" />
   </ItemGroup>

--- a/src/Functions/DelegationEventsPoison.cs
+++ b/src/Functions/DelegationEventsPoison.cs
@@ -10,15 +10,25 @@ namespace Altinn.Platform.Authorization.Functions;
 /// </summary>
 public class DelegationEventsPoison
 {
+    private readonly ILogger<DelegationEventsPoison> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DelegationEventsPoison"/> class.
+    /// </summary>
+    /// <param name="logger">The logger</param>
+    public DelegationEventsPoison(ILogger<DelegationEventsPoison> logger)
+    {
+        _logger = logger;
+    }
+
     /// <summary>
     /// Logs the failed message to Application Insights.
     /// </summary>
     /// <param name="queueMessage">The queue message.</param>
-    /// <param name="log">The log.</param>
     [FunctionName(nameof(DelegationEventsPoison))]
-    public void Run([QueueTrigger("delegationevents-poison", Connection = "QueueStorage")] QueueMessage queueMessage, ILogger log)
+    public void Run([QueueTrigger("delegationevents-poison", Connection = "QueueStorage")] QueueMessage queueMessage)
     {
-        log.LogCritical(
+        _logger.LogCritical(
             "Failed processing delegation queue item: id={id}, inserted={inserted}, expires={expires}, body={body}",
             queueMessage.MessageId,
             queueMessage.InsertedOn,


### PR DESCRIPTION
## Description
Bumping Microsoft.Extensions.Http dependency to 7.0.0 to match version used by AccessTokenClient 1.1.4 dependencies to see if this fixes runtime issues after the AccessTokenClien upgrade

## Related Issue(s)
- #444

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green
