### PR TITLE
Reverting patch of AccessTokenClient from 1.1.4 to 1.1.3

### DIFF
--- a/src/Functions/Altinn.Platform.Authorization.Functions.csproj
+++ b/src/Functions/Altinn.Platform.Authorization.Functions.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.1.3" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.2.0" />
-    <PackageReference Include="Altinn.Common.AccessTokenClient" Version="1.1.4" />
+    <PackageReference Include="Altinn.Common.AccessTokenClient" Version="1.1.3" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">


### PR DESCRIPTION
## Description
The patching of AccessTokenClient from 1.1.3 to 1.1.4 seems to cause a lot of runtime issues for the DelegationEvent Function

## Related Issue(s)
- #444 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] All tests run green
