### PR TITLE
Rollback of Microsoft.Extensions.Http patch and extended BridgeRequestFailedException

### DIFF
--- a/src/Functions/Altinn.Platform.Authorization.Functions.csproj
+++ b/src/Functions/Altinn.Platform.Authorization.Functions.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.1.3" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.2-mauipre.1.22102.15" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.2.0" />
     <PackageReference Include="Altinn.Common.AccessTokenClient" Version="1.1.3" />
   </ItemGroup>

--- a/src/Functions/Exceptions/BridgeRequestFailedException.cs
+++ b/src/Functions/Exceptions/BridgeRequestFailedException.cs
@@ -1,10 +1,47 @@
 using System;
+using System.Runtime.Serialization;
 
 namespace Altinn.Platform.Authorization.Functions.Exceptions;
 
 /// <summary>
 /// Generic exception used to trigger re-queueing of messages
 /// </summary>
+[Serializable]
 public class BridgeRequestFailedException : Exception
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BridgeRequestFailedException"/> class.
+    /// </summary>
+    public BridgeRequestFailedException()
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BridgeRequestFailedException"/> class.
+    /// </summary>
+    /// <param name="message">Error message</param>
+    public BridgeRequestFailedException(string message)
+        : base(message)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BridgeRequestFailedException"/> class.
+    /// </summary>
+    /// <param name="message">Error message</param>
+    /// <param name="innerException">Inner exception</param>
+    public BridgeRequestFailedException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BridgeRequestFailedException"/> class.
+    /// </summary>
+    /// <param name="info">Serialization info</param>
+    /// <param name="context">Context</param>
+    protected BridgeRequestFailedException(SerializationInfo info, StreamingContext context)
+        : base(info, context)
+    {
+    }
 }

--- a/src/Functions/Services/EventPusherService.cs
+++ b/src/Functions/Services/EventPusherService.cs
@@ -43,7 +43,7 @@ public class EventPusherService : IEventPusherService
             if (delegationChangeEventList == null)
             {
                 _logger.LogError("Received null instead of delegation change events. Failed to deserialize model?");
-                throw new BridgeRequestFailedException();
+                throw new BridgeRequestFailedException("Received null instead of delegation change events. Failed to deserialize model?");
             }
 
             delegationChangeEventList.DelegationChangeEvents ??= new List<DelegationChangeEvent>();
@@ -75,7 +75,7 @@ public class EventPusherService : IEventPusherService
                     GetChangeIdsForLog(delegationChangeEventList));
 
                 // Throw exception to ensure requeue of the event list
-                throw new BridgeRequestFailedException();
+                throw new BridgeRequestFailedException($"Bridge returned non-success. resultCode={response.StatusCode} reasonPhrase={response.ReasonPhrase} resultBody={await response.Content.ReadAsStringAsync()} numEventsSent={delegationChangeEventList.DelegationChangeEvents.Count} changeIds={GetChangeIdsForLog(delegationChangeEventList)}");
             }
 
             if (_logger.IsEnabled(LogLevel.Debug))
@@ -99,7 +99,7 @@ public class EventPusherService : IEventPusherService
                 delegationChangeEventList?.DelegationChangeEvents?.Count,
                 GetChangeIdsForLog(delegationChangeEventList));
 
-            throw new BridgeRequestFailedException();
+            throw new BridgeRequestFailedException($"Exception thrown while attempting to post delegation events to Bridge. exception={ex.GetType().Name} message={ex.Message} numEventsSent={delegationChangeEventList?.DelegationChangeEvents?.Count} changeIds={GetChangeIdsForLog(delegationChangeEventList)}", ex);
         }
     }
 


### PR DESCRIPTION
## Description
Rollback of Microsoft.Extensions.Http patch from 7.0.0 back to the original 6.0.2-mauipre.1.22102.15 which is the final patch change which might be the cause of failures.

BridgeRequestFailedException have been extended to be able to set message and inner exception as these now are just empty execeptions which makes debugging failure harder.

## Related Issue(s)
- #444

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

