### PR TITLE
ABAC XacmlPolicy attribute dictionary helper method

### DIFF
--- a/src/Altinn.Authorization.ABAC/Altinn.Authorization.ABAC.csproj
+++ b/src/Altinn.Authorization.ABAC/Altinn.Authorization.ABAC.csproj
@@ -3,14 +3,14 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <AssemblyVersion>0.0.0.5</AssemblyVersion>
-    <FileVersion>0.0.0.5</FileVersion>
+    <AssemblyVersion>0.0.0.6</AssemblyVersion>
+    <FileVersion>0.0.0.6</FileVersion>
     <!-- SonarCloud requires a ProjectGuid to separate projects. -->
     <ProjectGuid>{C9ABF5DB-928C-4280-B587-13E6DCE010BC}</ProjectGuid>
 
     <!-- NuGet package properties -->
     <PackageId>Altinn.Authorization.ABAC</PackageId>
-    <PackageVersion>0.0.5</PackageVersion>
+    <PackageVersion>0.0.6</PackageVersion>
     <PackageTags>Altinn;Authorization;ABAC</PackageTags>
     <Description>
       Attribute Based Access Control library for .Net Core implementing XACML 3.0 xml and JSON Profile.

--- a/src/Altinn.Authorization.ABAC/Xacml/XacmlPolicy.cs
+++ b/src/Altinn.Authorization.ABAC/Xacml/XacmlPolicy.cs
@@ -98,7 +98,7 @@ namespace Altinn.Authorization.ABAC.Xacml
 
         private readonly ICollection<XacmlVariableDefinition> variableDefinitions = new Collection<XacmlVariableDefinition>();
 
-        private readonly IDictionary<string, IDictionary<string, Collection<string>>> categoryAttributes = new Dictionary<string, IDictionary<string, Collection<string>>>();
+        private readonly IDictionary<string, IDictionary<string, ICollection<string>>> categoryAttributes = new Dictionary<string, IDictionary<string, ICollection<string>>>();
 
         private XacmlTarget target;
         private Uri policyId;
@@ -317,14 +317,14 @@ namespace Altinn.Authorization.ABAC.Xacml
         /// </summary>
         /// <param name="matchAttributeCategory">The Xacml match attribute category to collect attributes values of</param>
         /// <returns>Dictionary of attribute ids and list of values</returns>
-        public IDictionary<string, Collection<string>> GetAttributeDictionaryByCategory(string matchAttributeCategory)
+        public IDictionary<string, ICollection<string>> GetAttributeDictionaryByCategory(string matchAttributeCategory)
         {
             if (categoryAttributes.ContainsKey(matchAttributeCategory))
             {
                 return categoryAttributes[matchAttributeCategory];
             }
 
-            IDictionary<string, Collection<string>> categoryAttributeDict = new Dictionary<string, Collection<string>>();
+            IDictionary<string, ICollection<string>> categoryAttributeDict = new Dictionary<string, ICollection<string>>();
             categoryAttributes.Add(matchAttributeCategory, categoryAttributeDict);
 
             foreach (XacmlRule rule in Rules)

--- a/src/Altinn.Authorization.ABAC/Xacml/XacmlPolicy.cs
+++ b/src/Altinn.Authorization.ABAC/Xacml/XacmlPolicy.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
+using Altinn.Authorization.ABAC.Constants;
 using Altinn.Authorization.ABAC.Utils;
 
 namespace Altinn.Authorization.ABAC.Xacml
@@ -95,6 +97,8 @@ namespace Altinn.Authorization.ABAC.Xacml
         private readonly ICollection<XacmlObligationExpression> obligationExpressions = new Collection<XacmlObligationExpression>();
 
         private readonly ICollection<XacmlVariableDefinition> variableDefinitions = new Collection<XacmlVariableDefinition>();
+
+        private readonly IDictionary<string, IDictionary<string, Collection<string>>> categoryAttributes = new Dictionary<string, IDictionary<string, Collection<string>>>();
 
         private XacmlTarget target;
         private Uri policyId;
@@ -306,6 +310,51 @@ namespace Altinn.Authorization.ABAC.Xacml
             {
                 return this.adviceExpressions;
             }
+        }
+
+        /// <summary>
+        /// Returns a dictionary of all unique attribute ids and a collection of all their values, which exists across all rules in the policy, for a given match attribute category.
+        /// </summary>
+        /// <param name="matchAttributeCategory">The Xacml match attribute category to collect attributes values of</param>
+        /// <returns>Dictionary of attribute ids and list of values</returns>
+        public IDictionary<string, Collection<string>> GetAttributeDictionaryByCategory(string matchAttributeCategory)
+        {
+            if (categoryAttributes.ContainsKey(matchAttributeCategory))
+            {
+                return categoryAttributes[matchAttributeCategory];
+            }
+
+            IDictionary<string, Collection<string>> categoryAttributeDict = new Dictionary<string, Collection<string>>();
+            categoryAttributes.Add(matchAttributeCategory, categoryAttributeDict);
+
+            foreach (XacmlRule rule in Rules)
+            {
+                // should we care about permit?
+                if (rule.Effect.Equals(XacmlEffectType.Permit) && rule.Target != null)
+                {
+                    foreach (XacmlAnyOf anyOf in rule.Target.AnyOf)
+                    {
+                        foreach (XacmlAllOf allOf in anyOf.AllOf)
+                        {
+                            foreach (XacmlMatch xacmlMatch in allOf.Matches)
+                            {
+                                if (xacmlMatch.AttributeDesignator.Category.Equals(matchAttributeCategory))
+                                {
+                                    string attributeId = xacmlMatch.AttributeDesignator.AttributeId.AbsoluteUri;
+                                    if (!categoryAttributeDict.ContainsKey(attributeId))
+                                    {
+                                        categoryAttributeDict.Add(attributeId, new Collection<string>());
+                                    }
+
+                                    categoryAttributeDict[attributeId].Add(xacmlMatch.AttributeValue.Value);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            return categoryAttributes[matchAttributeCategory];
         }
 
         /// <summary>


### PR DESCRIPTION
## Description
As part of the integration with OED/DD (Digitalt dødsbo) as a new external role provider, an easy way to analyse and extract all attributeIds and values from a XacmlPolicy is needed. This will be used to evaluate whether or not the policy contains a subject attribute for an OED/DD role code, and since it's populated to the XacmlPolicy object it will be cached along side policy itself.

The logic can later be reused by the resource-registry which will need same logic for analysing the policy for building rolecode register and required validation logic when publishing a resource.

## Related Issue(s)
- #474

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
