### PR TITLE
Semaphore locking XacmlPolicy.GetAttributeDictionaryByCategory

### DIFF
--- a/src/Altinn.Authorization.ABAC/Altinn.Authorization.ABAC.csproj
+++ b/src/Altinn.Authorization.ABAC/Altinn.Authorization.ABAC.csproj
@@ -3,14 +3,14 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <OutputType>Library</OutputType>
-    <AssemblyVersion>0.0.0.6</AssemblyVersion>
-    <FileVersion>0.0.0.6</FileVersion>
+    <AssemblyVersion>0.0.0.7</AssemblyVersion>
+    <FileVersion>0.0.0.7</FileVersion>
     <!-- SonarCloud requires a ProjectGuid to separate projects. -->
     <ProjectGuid>{C9ABF5DB-928C-4280-B587-13E6DCE010BC}</ProjectGuid>
 
     <!-- NuGet package properties -->
     <PackageId>Altinn.Authorization.ABAC</PackageId>
-    <PackageVersion>0.0.6</PackageVersion>
+    <PackageVersion>0.0.7</PackageVersion>
     <PackageTags>Altinn;Authorization;ABAC</PackageTags>
     <Description>
       Attribute Based Access Control library for .Net Core implementing XACML 3.0 xml and JSON Profile.


### PR DESCRIPTION
## Description
Should avoid the ArgumentException which sometimes occurs on GetAttributeDictionaryByCategory after it's introduction with the DD/OED-role integration.

## Related Issue(s)
- #500

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
