### PR TITLE
Patch bump of dependencies without breaking Microsoft.IdentityModel.Protocols.OpenIdConnect

### DIFF
--- a/src/Authorization/Altinn.Platform.Authorization.csproj
+++ b/src/Authorization/Altinn.Platform.Authorization.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Altinn.ApiClients.Maskinporten" Version="9.0.0" />
+    <PackageReference Include="Altinn.ApiClients.Maskinporten" Version="9.1.0" />
     <PackageReference Include="Altinn.Common.AccessTokenClient" Version="1.1.4" />
     <PackageReference Include="Altinn.Common.PEP" Version="1.3.0" />
     <PackageReference Include="Altinn.Platform.Models" Version="1.2.0" />
-    <PackageReference Include="Azure.Identity" Version="1.10.1" />
+    <PackageReference Include="Azure.Identity" Version="1.10.2" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.5.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.18.0" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.16.0" />
@@ -23,6 +23,7 @@
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureKeyVault" Version="3.1.24" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="7.0.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="7.0.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Yuniql.AspNetCore" Version="1.2.25" />
     <PackageReference Include="Yuniql.PostgreSql" Version="1.3.15" />


### PR DESCRIPTION
## Description
Patching of Altinn.ApiClients.Maskinporten to 9.1.0 includes bump of Microsoft.IdentityModel.Tokens from 6.32.1 to 7.0.2.
This also require bump of Microsoft.IdentityModel.Protocols.OpenIdConnect from 6.32.1 to 7.0.2 in order to not be breaking.
Currently authorization gets Microsoft.IdentityModel.Protocols.OpenIdConnect through Altinn.Common.AccessTokenClient 1.1.4 which is currently still on 6.32.1

## Related Issue(s)
- #512

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
