### PR TITLE
Bump ABAC to 0.0.7

### DIFF
--- a/src/Authorization/Altinn.Platform.Authorization.csproj
+++ b/src/Authorization/Altinn.Platform.Authorization.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Azure.Storage.Blobs" Version="12.18.0" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.16.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
-    <PackageReference Include="Altinn.Authorization.ABAC" Version="0.0.6" />
+    <PackageReference Include="Altinn.Authorization.ABAC" Version="0.0.7" />
     <PackageReference Include="Altinn.Platform.Storage.Interface" Version="3.24.0" />
     <PackageReference Include="JWTCookieAuthentication" Version="3.0.1" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.20.0" />


### PR DESCRIPTION
## Description
Bumps ABAC package from 0.0.6 to 0.0.7 which includes fix for possible duplicate key issues when building the attribute dictionary for a given attribute category.

Obligatory 007 puns:
Dr. No Access
From Authorization with Love
Gold-policy
Thunderrule
You Only Get Access Twice
On Her Majesty's Authorization Service
Authorizations Are Forever
Live and Let Deny Access
The Man with the Golden Grant
The Spy Who Authorized Me
Policyraker
For Your Policy Only
Octopolicy
A View to a Permit
The Living Day-Access
License to Authorize
PolicyEye
Tomorrow Never Denies (access)
The World Is Not Authorized
Deny Another Day
Casino XacmlRule
Quantum of Authorization
Authfall
Spec-Xacml-tre
No Time to Deny

## Related Issue(s)
- #500

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
