### PR TITLE
Bumping Microsoft.Extensions.Http version to 7.0.0

### DIFF
--- a/src/Functions/Altinn.Platform.Authorization.Functions.csproj
+++ b/src/Functions/Altinn.Platform.Authorization.Functions.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.21.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.2.1" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.2-mauipre.1.22102.15" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.2.0" />
     <PackageReference Include="Altinn.Common.AccessTokenClient" Version="1.1.5" />
   </ItemGroup>


### PR DESCRIPTION
## Description
Bumping Microsoft.Extensions.Http version to 7.0.0 for consistent sub dependency versions with other dependencies (AccessTokenClient)

## Related Issue(s)
- #541

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
