### PR TITLE
Configure forwardheader middleware

### DIFF
--- a/src/Authorization/Helpers/EventLogHelper.cs
+++ b/src/Authorization/Helpers/EventLogHelper.cs
@@ -176,15 +176,8 @@ namespace Altinn.Platform.Authorization.Helpers
         /// <returns></returns>
         public static string GetClientIpAddress(HttpContext context)
         {
-            // Try to get the client IP address from the X-Real-IP header
-            var clientIp = context.Request.Headers["X-Real-IP"].FirstOrDefault();
-
-            // If the X-Real-IP header is not present, fall back to the RemoteIpAddress property
-            if (string.IsNullOrEmpty(clientIp))
-            {
-                clientIp = context.Connection.RemoteIpAddress?.ToString();
-            }
-
+            // The first ipaddress in the x-forwarded-for header is the client ipaddress. The ip from x-forwarded-for is read into remoteip depending on the forward limit
+            string clientIp = context?.Connection?.RemoteIpAddress?.ToString();
             return clientIp;
         }
     }


### PR DESCRIPTION
Added forwarded headers middleware to map the client ip to the remote ip property of the httpcontext. 

When the explicit configuration is not present, the mapping does not work. This is because the defaults looks like 

- RequireHeaderSymmetry = true,  which looks for that all the forwardheaders(proto, for, host) have same number of values 
- ForwardLimit = 1 which reads the 1st value from the right


Refer https://blog.novanet.no/parameter-count-mismatch-between-x-forwarded-for-and-x-forwarded-proto/
explains how this middleware actually works.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
