### PR TITLE
Implement party lookup in IParties (fixes #600)

### DIFF
--- a/src/Authorization/Services/Implementation/ContextHandler.cs
+++ b/src/Authorization/Services/Implementation/ContextHandler.cs
@@ -181,10 +181,10 @@ namespace Altinn.Platform.Authorization.Services.Implementation
         {
             if (string.IsNullOrEmpty(resourceAttributes.ResourcePartyValue) && !string.IsNullOrEmpty(resourceAttributes.OrganizationNumber))
             {
-                int partyId = await _registerService.PartyLookup(resourceAttributes.OrganizationNumber, null);
-                if (partyId != 0)
+                Party party = await _partiesWrapper.LookupPartyBySSNOrOrgNo(resourceAttributes.OrganizationNumber);
+                if (party != null)
                 {
-                    resourceAttributes.ResourcePartyValue = partyId.ToString();
+                    resourceAttributes.ResourcePartyValue = party.PartyId.ToString();
                 }
             }
         }
@@ -467,7 +467,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
         /// </summary>
         /// <param name="from">the party which the role assignment provides access on behalf of</param>
         /// <param name="to">the role assignment recipient party</param>
-        /// <returns>list of OED/Digitalt dødsbo Role Assignments</returns>
+        /// <returns>list of OED/Digitalt dÃ¸dsbo Role Assignments</returns>
         protected async Task<List<OedRoleAssignment>> GetOedRoleAssignments(string from, string to)
         {
             string cacheKey = GetOedRoleassignmentCacheKey(from, to);

--- a/src/Authorization/Services/Implementation/PartiesWrapper.cs
+++ b/src/Authorization/Services/Implementation/PartiesWrapper.cs
@@ -162,5 +162,34 @@ namespace Altinn.Platform.Authorization.Services.Implementation
 
             return result;
         }
+
+        /// <inheritdoc />
+        public async Task<Party> LookupPartyBySSNOrOrgNo(string lookupValue)
+        {
+            try
+            {
+                Uri endpointUrl = new($"register/api/parties/lookupObject");
+                StringContent requestBody = new(JsonConvert.SerializeObject(lookupValue), Encoding.UTF8, "application/json");
+
+                HttpResponseMessage response = await _partyClient.Client.PostAsync(endpointUrl, requestBody);
+                var responseBody = await response.Content.ReadAsStringAsync();
+
+                if (response.IsSuccessStatusCode)
+                {
+                    return JsonConvert.DeserializeObject<Party>(responseBody);
+                }
+                else
+                {
+                    _logger.LogError("SBL-Bridge // PartiesWrapper // LookupPartyBySSNOrOrgNo // Failed // Unexpected HttpStatusCode: {response.StatusCode}\n {responseBody}", response.StatusCode, responseBody);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "SBL-Bridge // PartiesWrapper // LookupPartyBySSNOrOrgNo // Failed // Unexpected Exception");
+                throw;
+            }
+
+            return null;
+        }
     }
 }

--- a/src/Authorization/Services/Interface/IParties.cs
+++ b/src/Authorization/Services/Interface/IParties.cs
@@ -45,5 +45,12 @@ namespace Altinn.Platform.Authorization.Services.Interface
         /// <param name="partyId">The party id"</param>
         /// <returns> Boolean indicating whether or not the user can represent the selected party.</returns>
         Task<bool> ValidateSelectedParty(int userId, int partyId);
+
+        /// <summary>
+        /// Method that fetches a party based on social security number or organisation number.
+        /// </summary>
+        /// <param name="lookupValue">SSN or org number</param>
+        /// <returns></returns>
+        Task<Party> LookupPartyBySSNOrOrgNo(string lookupValue);
     }
 }

--- a/test/IntegrationTests/MockServices/PartiesMock.cs
+++ b/test/IntegrationTests/MockServices/PartiesMock.cs
@@ -63,7 +63,13 @@ namespace Altinn.Platform.Authorization.IntegrationTests.MockServices
 
         public Task<Party> LookupPartyBySSNOrOrgNo(string lookupValue)
         {
-            throw new NotImplementedException();
+            Party party = null;
+            if (lookupValue == "950474084")
+            {
+                party = new Party { PartyId = 500700 };
+            }
+
+            return Task.FromResult(party);
         }
 
         public Task<bool> ValidateSelectedParty(int userId, int partyId)

--- a/test/IntegrationTests/MockServices/PartiesMock.cs
+++ b/test/IntegrationTests/MockServices/PartiesMock.cs
@@ -61,6 +61,11 @@ namespace Altinn.Platform.Authorization.IntegrationTests.MockServices
             return Task.FromResult(party);
         }
 
+        public Task<Party> LookupPartyBySSNOrOrgNo(string lookupValue)
+        {
+            throw new NotImplementedException();
+        }
+
         public Task<bool> ValidateSelectedParty(int userId, int partyId)
         {
             throw new NotImplementedException();


### PR DESCRIPTION
This implements party lookup via `IParties` for resource party enrichment, bypassing `IRegisterService`

## Description
This will cause organization number-to-partyid lookups to use IParties directly, allowing the use of organization numbers as resource parties in PDP requests.

## Related Issue(s)
- #600

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
