### PR TITLE
Rollback of Altinn.Common.AccessTokenClient from 1.1.5 to 1.1.3 (again)

### DIFF
--- a/src/Functions/Altinn.Platform.Authorization.Functions.csproj
+++ b/src/Functions/Altinn.Platform.Authorization.Functions.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.2.2" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.2-mauipre.1.22102.15" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.2.0" />
-    <PackageReference Include="Altinn.Common.AccessTokenClient" Version="1.1.5" />
+    <PackageReference Include="Altinn.Common.AccessTokenClient" Version="1.1.3" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">


### PR DESCRIPTION
Newer versions of Altinn.Common.AccessTokenClient than 1.1.3 is breaking for function app atm. and needs to be rolled back
