### PR TITLE
Adding package rule to renovate config to lock AccessTokenClient to version 1.1.3

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,12 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>Altinn/renovate-config"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": [ "Altinn.Common.AccessTokenClient" ],
+      "matchPaths": [ "src/Functions/**" ],
+      "allowedVersions": "<=1.1.3"
+    }
   ]
 }


### PR DESCRIPTION
Adding package rule to renovate config to lock AccessTokenClient to version 1.1.3 for the DelegationEvent function app
