### PR TITLE
Added a property for xforwardedfor header

### DIFF
--- a/src/Altinn.Authorization.ABAC/Altinn.Authorization.ABAC.csproj
+++ b/src/Altinn.Authorization.ABAC/Altinn.Authorization.ABAC.csproj
@@ -35,6 +35,10 @@
     </AdditionalFiles>
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="8.0.1" />
+  </ItemGroup>
+
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
     <CodeAnalysisRuleSet>..\..\Altinn3.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>

--- a/src/Altinn.Authorization.ABAC/Xacml/JsonProfile/XacmlJsonRequest.cs
+++ b/src/Altinn.Authorization.ABAC/Xacml/JsonProfile/XacmlJsonRequest.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
 
 namespace Altinn.Authorization.ABAC.Xacml.JsonProfile
 {
@@ -68,6 +69,7 @@ namespace Altinn.Authorization.ABAC.Xacml.JsonProfile
         /// <summary>
         /// Gets the x-forwarded-for header value from the request headers of app
         /// </summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.Always)]
         public string XForwardedForHeader { get; set; }
     }
 }

--- a/src/Altinn.Authorization.ABAC/Xacml/JsonProfile/XacmlJsonRequest.cs
+++ b/src/Altinn.Authorization.ABAC/Xacml/JsonProfile/XacmlJsonRequest.cs
@@ -64,5 +64,10 @@ namespace Altinn.Authorization.ABAC.Xacml.JsonProfile
         /// Gets or sets references to multiple requests.
         /// </summary>
         public XacmlJsonMultiRequests MultiRequests { get; set; }
+
+        /// <summary>
+        /// Gets the x-forwarded-for header value from the request headers of app
+        /// </summary>
+        public string XForwardedForHeader { get; set; }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This property will be used in the PEP package to store the x-forwarded-for header value from the app and will be then set as a header to the authorization request

## Related Issue(s)
- https://github.com/Altinn/altinn-auth-audit-log/issues/62

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
