### PR TITLE
Remove use of ClaimValueType directly in XACML request

### DIFF
--- a/src/Altinn.Common.PEP/Altinn.Common.PEP/Helpers/DecisionHelper.cs
+++ b/src/Altinn.Common.PEP/Altinn.Common.PEP/Helpers/DecisionHelper.cs
@@ -179,15 +179,15 @@ namespace Altinn.Common.PEP.Helpers
             {
                 if (IsCamelCaseOrgnumberClaim(claim.Type))
                 {
-                    attributes.Add(CreateXacmlJsonAttribute(AltinnXacmlUrns.OrganizationNumber, claim.Value, claim.ValueType, claim.Issuer));
+                    attributes.Add(CreateXacmlJsonAttribute(AltinnXacmlUrns.OrganizationNumber, claim.Value, DefaultType, claim.Issuer));
                 }
                 else if (IsScopeClaim(claim.Type))
                 {
-                    attributes.Add(CreateXacmlJsonAttribute(AltinnXacmlUrns.Scope, claim.Value, claim.ValueType, claim.Issuer));
+                    attributes.Add(CreateXacmlJsonAttribute(AltinnXacmlUrns.Scope, claim.Value, DefaultType, claim.Issuer));
                 }
                 else if (IsValidUrn(claim.Type))
                 {
-                    attributes.Add(CreateXacmlJsonAttribute(claim.Type, claim.Value, claim.ValueType, claim.Issuer));
+                    attributes.Add(CreateXacmlJsonAttribute(claim.Type, claim.Value, DefaultType, claim.Issuer));
                 }
             }
 


### PR DESCRIPTION
## Description
Using the ClaimValueType directly fails for integers which after Microsoft.IdentityModel version 7 use Integer32 as datatype, which the current XACML implementation don't support.

## Related Issue(s)
- #688

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
