### PR TITLE
Modified getclientip to get client ip based on api or app call

### DIFF
--- a/src/Authorization/Helpers/EventLogHelper.cs
+++ b/src/Authorization/Helpers/EventLogHelper.cs
@@ -177,7 +177,19 @@ namespace Altinn.Platform.Authorization.Helpers
         public static string GetClientIpAddress(HttpContext context)
         {
             // The first ipaddress in the x-forwarded-for header is the client ipaddress. The ip from x-forwarded-for is read into remoteip depending on the forward limit
-            string clientIp = context?.Connection?.RemoteIpAddress?.ToString();
+            //string clientIp = context?.Connection?.RemoteIpAddress?.ToString();
+            string clientIp = null;
+            string clientIpList = context?.Request?.Headers?["x-forwarded-for"];
+            string[] ipAddress = clientIpList?.Split(',');
+            if (ipAddress?.Length == 3)
+            {
+                clientIp = ipAddress[0];
+            }
+            else if (ipAddress?.Length == 2)
+            {
+                clientIp = ipAddress[1];
+            }
+
             return clientIp;
         }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
when there are 3 ips, it means the call is from the app and when it is 2, it means it just an api call from some client

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
