### PR TITLE
Reuse authinfo in context handler

### DIFF
--- a/src/Authorization/Controllers/DecisionController.cs
+++ b/src/Authorization/Controllers/DecisionController.cs
@@ -53,7 +53,7 @@ namespace Altinn.Platform.Authorization.Controllers
         private readonly IAccessManagementWrapper _accessManagement;
         private readonly IMapper _mapper;
 
-        private readonly SortedDictionary<string, AuthInfo> _authInfoForOneDecReq = new();
+        private readonly SortedDictionary<string, AuthInfo> _appInstanceInfo = new();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DecisionController"/> class.
@@ -262,7 +262,7 @@ namespace Altinn.Platform.Authorization.Controllers
 
         private async Task<XacmlContextResponse> Authorize(XacmlContextRequest decisionRequest, bool isExernalRequest, bool logEvent = true, CancellationToken cancellationToken = default)
         {
-            decisionRequest = await this._contextHandler.Enrich(decisionRequest, isExernalRequest, _authInfoForOneDecReq);
+            decisionRequest = await this._contextHandler.Enrich(decisionRequest, isExernalRequest, _appInstanceInfo);
 
             ////_logger.LogInformation($"// DecisionController // Authorize // Roles // Enriched request: {JsonConvert.SerializeObject(decisionRequest)}.");
             XacmlPolicy policy = await _prp.GetPolicyAsync(decisionRequest);

--- a/src/Authorization/Controllers/DecisionController.cs
+++ b/src/Authorization/Controllers/DecisionController.cs
@@ -53,7 +53,7 @@ namespace Altinn.Platform.Authorization.Controllers
         private readonly IAccessManagementWrapper _accessManagement;
         private readonly IMapper _mapper;
 
-        private readonly SortedDictionary<string, AuthInfo> _authInfoCache = new();
+        private readonly SortedDictionary<string, AuthInfo> _authInfoForOneDecReq = new();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DecisionController"/> class.
@@ -262,7 +262,7 @@ namespace Altinn.Platform.Authorization.Controllers
 
         private async Task<XacmlContextResponse> Authorize(XacmlContextRequest decisionRequest, bool isExernalRequest, bool logEvent = true, CancellationToken cancellationToken = default)
         {
-            decisionRequest = await this._contextHandler.Enrich(decisionRequest, isExernalRequest, _authInfoCache);
+            decisionRequest = await this._contextHandler.Enrich(decisionRequest, isExernalRequest, _authInfoForOneDecReq);
 
             ////_logger.LogInformation($"// DecisionController // Authorize // Roles // Enriched request: {JsonConvert.SerializeObject(decisionRequest)}.");
             XacmlPolicy policy = await _prp.GetPolicyAsync(decisionRequest);

--- a/src/Authorization/Controllers/DecisionController.cs
+++ b/src/Authorization/Controllers/DecisionController.cs
@@ -19,6 +19,7 @@ using Altinn.Platform.Authorization.Models.External;
 using Altinn.Platform.Authorization.Repositories.Interface;
 using Altinn.Platform.Authorization.Services.Interface;
 using Altinn.Platform.Authorization.Services.Interfaces;
+using Altinn.Platform.Storage.Interface.Models;
 using AutoMapper;
 using Azure.Core;
 using Microsoft.AspNetCore.Authorization;
@@ -51,6 +52,8 @@ namespace Altinn.Platform.Authorization.Controllers
         private readonly IFeatureManager _featureManager;
         private readonly IAccessManagementWrapper _accessManagement;
         private readonly IMapper _mapper;
+
+        private readonly SortedDictionary<string, AuthInfo> _authInfoCache = new();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DecisionController"/> class.
@@ -259,7 +262,7 @@ namespace Altinn.Platform.Authorization.Controllers
 
         private async Task<XacmlContextResponse> Authorize(XacmlContextRequest decisionRequest, bool isExernalRequest, bool logEvent = true, CancellationToken cancellationToken = default)
         {
-            decisionRequest = await this._contextHandler.Enrich(decisionRequest, isExernalRequest);
+            decisionRequest = await this._contextHandler.Enrich(decisionRequest, isExernalRequest, _authInfoCache);
 
             ////_logger.LogInformation($"// DecisionController // Authorize // Roles // Enriched request: {JsonConvert.SerializeObject(decisionRequest)}.");
             XacmlPolicy policy = await _prp.GetPolicyAsync(decisionRequest);

--- a/src/Authorization/Services/Implementation/ContextHandler.cs
+++ b/src/Authorization/Services/Implementation/ContextHandler.cs
@@ -69,7 +69,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
         }
 
         /// <inheritdoc/>
-        public async Task<XacmlContextRequest> Enrich(XacmlContextRequest request, bool isExternalRequest, SortedDictionary<string, AuthInfo> authInfoForOneDecReq)
+        public async Task<XacmlContextRequest> Enrich(XacmlContextRequest request, bool isExternalRequest, SortedDictionary<string, AuthInfo> appInstanceInfo)
         {
             await EnrichResourceAttributes(request, isExternalRequest, appInstanceInfo);
             return await Task.FromResult(request);
@@ -80,8 +80,8 @@ namespace Altinn.Platform.Authorization.Services.Implementation
         /// </summary>
         /// <param name="request">The original Xacml Context Request</param>
         /// <param name="isExternalRequest">Defines if request comes </param>
-        /// <param name="authInfoForOneDecReq">Cache of auto info for this request</param>
-        protected async Task EnrichResourceAttributes(XacmlContextRequest request, bool isExternalRequest, SortedDictionary<string, AuthInfo> authInfoForOneDecReq)
+        /// <param name="appInstanceInfo">Cache of auto info for this request</param>
+        protected async Task EnrichResourceAttributes(XacmlContextRequest request, bool isExternalRequest, SortedDictionary<string, AuthInfo> appInstanceInfo)
         {
             XacmlContextAttributes resourceContextAttributes = request.GetResourceAttributes();
             XacmlResourceAttributes resourceAttributes = GetResourceAttributeValues(resourceContextAttributes);
@@ -100,10 +100,10 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                 {
                     instanceData = new();
                     
-                    if (!authInfoForOneDecReq.TryGetValue(resourceAttributes.InstanceValue, out AuthInfo authInfo))
+                    if (!appInstanceInfo.TryGetValue(resourceAttributes.InstanceValue, out AuthInfo authInfo))
                     {
                         authInfo = await _policyInformationRepository.GetAuthInfo(resourceAttributes.InstanceValue);
-                        authInfoForOneDecReq[resourceAttributes.InstanceValue] = authInfo;
+                        appInstanceInfo[resourceAttributes.InstanceValue] = authInfo;
                     }
 
                     instanceData.Process = authInfo.Process;

--- a/src/Authorization/Services/Implementation/ContextHandler.cs
+++ b/src/Authorization/Services/Implementation/ContextHandler.cs
@@ -69,9 +69,9 @@ namespace Altinn.Platform.Authorization.Services.Implementation
         }
 
         /// <inheritdoc/>
-        public async Task<XacmlContextRequest> Enrich(XacmlContextRequest request, bool isExternalRequest, SortedDictionary<string, AuthInfo> authInfoCache)
+        public async Task<XacmlContextRequest> Enrich(XacmlContextRequest request, bool isExternalRequest, SortedDictionary<string, AuthInfo> authInfoForOneDecReq)
         {
-            await EnrichResourceAttributes(request, isExternalRequest, authInfoCache);
+            await EnrichResourceAttributes(request, isExternalRequest, authInfoForOneDecReq);
             return await Task.FromResult(request);
         }
 
@@ -80,8 +80,8 @@ namespace Altinn.Platform.Authorization.Services.Implementation
         /// </summary>
         /// <param name="request">The original Xacml Context Request</param>
         /// <param name="isExternalRequest">Defines if request comes </param>
-        /// <param name="authInfoCache">Cache of auto info for this request</param>
-        protected async Task EnrichResourceAttributes(XacmlContextRequest request, bool isExternalRequest, SortedDictionary<string, AuthInfo> authInfoCache)
+        /// <param name="authInfoForOneDecReq">Cache of auto info for this request</param>
+        protected async Task EnrichResourceAttributes(XacmlContextRequest request, bool isExternalRequest, SortedDictionary<string, AuthInfo> authInfoForOneDecReq)
         {
             XacmlContextAttributes resourceContextAttributes = request.GetResourceAttributes();
             XacmlResourceAttributes resourceAttributes = GetResourceAttributeValues(resourceContextAttributes);
@@ -100,10 +100,10 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                 {
                     instanceData = new();
                     
-                    if (!authInfoCache.TryGetValue(resourceAttributes.InstanceValue, out AuthInfo authInfo))
+                    if (!authInfoForOneDecReq.TryGetValue(resourceAttributes.InstanceValue, out AuthInfo authInfo))
                     {
                         authInfo = await _policyInformationRepository.GetAuthInfo(resourceAttributes.InstanceValue);
-                        authInfoCache[resourceAttributes.InstanceValue] = authInfo;
+                        authInfoForOneDecReq[resourceAttributes.InstanceValue] = authInfo;
                     }
 
                     instanceData.Process = authInfo.Process;

--- a/src/Authorization/Services/Implementation/ContextHandler.cs
+++ b/src/Authorization/Services/Implementation/ContextHandler.cs
@@ -68,15 +68,10 @@ namespace Altinn.Platform.Authorization.Services.Implementation
             _prp = prp;
         }
 
-        /// <summary>
-        /// Ads needed information to the Context Request.
-        /// </summary>
-        /// <param name="request">The original Xacml Context Request</param>
-        /// <param name="isExternalRequest">Defines if this is an external request</param>
-        /// <returns>The enriched XacmlContextRequest</returns>
-        public async Task<XacmlContextRequest> Enrich(XacmlContextRequest request, bool isExternalRequest)
+        /// <inheritdoc/>
+        public async Task<XacmlContextRequest> Enrich(XacmlContextRequest request, bool isExternalRequest, SortedDictionary<string, AuthInfo> authInfoCache)
         {
-            await EnrichResourceAttributes(request, isExternalRequest);
+            await EnrichResourceAttributes(request, isExternalRequest, authInfoCache);
             return await Task.FromResult(request);
         }
 
@@ -85,7 +80,8 @@ namespace Altinn.Platform.Authorization.Services.Implementation
         /// </summary>
         /// <param name="request">The original Xacml Context Request</param>
         /// <param name="isExternalRequest">Defines if request comes </param>
-        protected async Task EnrichResourceAttributes(XacmlContextRequest request, bool isExternalRequest)
+        /// <param name="authInfoCache">Cache of auto info for this request</param>
+        protected async Task EnrichResourceAttributes(XacmlContextRequest request, bool isExternalRequest, SortedDictionary<string, AuthInfo> authInfoCache)
         {
             XacmlContextAttributes resourceContextAttributes = request.GetResourceAttributes();
             XacmlResourceAttributes resourceAttributes = GetResourceAttributeValues(resourceContextAttributes);
@@ -103,7 +99,13 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                 else
                 {
                     instanceData = new();
-                    AuthInfo authInfo = await _policyInformationRepository.GetAuthInfo(resourceAttributes.InstanceValue);
+                    
+                    if (!authInfoCache.TryGetValue(resourceAttributes.InstanceValue, out AuthInfo authInfo))
+                    {
+                        authInfo = await _policyInformationRepository.GetAuthInfo(resourceAttributes.InstanceValue);
+                        authInfoCache[resourceAttributes.InstanceValue] = authInfo;
+                    }
+
                     instanceData.Process = authInfo.Process;
                     instanceData.AppId = authInfo.AppId;
                     instanceData.Org = instanceData.AppId.Split('/')[0];

--- a/src/Authorization/Services/Implementation/ContextHandler.cs
+++ b/src/Authorization/Services/Implementation/ContextHandler.cs
@@ -71,7 +71,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
         /// <inheritdoc/>
         public async Task<XacmlContextRequest> Enrich(XacmlContextRequest request, bool isExternalRequest, SortedDictionary<string, AuthInfo> authInfoForOneDecReq)
         {
-            await EnrichResourceAttributes(request, isExternalRequest, authInfoForOneDecReq);
+            await EnrichResourceAttributes(request, isExternalRequest, appInstanceInfo);
             return await Task.FromResult(request);
         }
 

--- a/src/Authorization/Services/Interface/IContextHandler.cs
+++ b/src/Authorization/Services/Interface/IContextHandler.cs
@@ -15,8 +15,8 @@ namespace Altinn.Platform.Authorization.Services.Interface
         /// </summary>
         /// <param name="decisionRequest">The XacmlContextRequest.</param>
         /// <param name="isExternalRequest">Defines if call is comming from external source</param>
-        /// <param name="authInfoCache">Cache of auto info for this request</param>
+        /// <param name="authInfoForOneDecReq">Cache of auth info for this request</param>
         /// <returns>Enriched context.</returns>
-        Task<XacmlContextRequest> Enrich(XacmlContextRequest decisionRequest, bool isExternalRequest, SortedDictionary<string, AuthInfo> authInfoCache);
+        Task<XacmlContextRequest> Enrich(XacmlContextRequest decisionRequest, bool isExternalRequest, SortedDictionary<string, AuthInfo> authInfoForOneDecReq);
     }
 }

--- a/src/Authorization/Services/Interface/IContextHandler.cs
+++ b/src/Authorization/Services/Interface/IContextHandler.cs
@@ -15,8 +15,8 @@ namespace Altinn.Platform.Authorization.Services.Interface
         /// </summary>
         /// <param name="decisionRequest">The XacmlContextRequest.</param>
         /// <param name="isExternalRequest">Defines if call is comming from external source</param>
-        /// <param name="authInfoForOneDecReq">Cache of auth info for this request</param>
+        /// <param name="appInstanceInfo">Cache of auth info for this request</param>
         /// <returns>Enriched context.</returns>
-        Task<XacmlContextRequest> Enrich(XacmlContextRequest decisionRequest, bool isExternalRequest, SortedDictionary<string, AuthInfo> authInfoForOneDecReq);
+        Task<XacmlContextRequest> Enrich(XacmlContextRequest decisionRequest, bool isExternalRequest, SortedDictionary<string, AuthInfo> appInstanceInfo);
     }
 }

--- a/src/Authorization/Services/Interface/IContextHandler.cs
+++ b/src/Authorization/Services/Interface/IContextHandler.cs
@@ -1,5 +1,7 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Altinn.Authorization.ABAC.Xacml;
+using Altinn.Platform.Storage.Interface.Models;
 
 namespace Altinn.Platform.Authorization.Services.Interface
 {
@@ -13,7 +15,8 @@ namespace Altinn.Platform.Authorization.Services.Interface
         /// </summary>
         /// <param name="decisionRequest">The XacmlContextRequest.</param>
         /// <param name="isExternalRequest">Defines if call is comming from external source</param>
+        /// <param name="authInfoCache">Cache of auto info for this request</param>
         /// <returns>Enriched context.</returns>
-        Task<XacmlContextRequest> Enrich(XacmlContextRequest decisionRequest, bool isExternalRequest);
+        Task<XacmlContextRequest> Enrich(XacmlContextRequest decisionRequest, bool isExternalRequest, SortedDictionary<string, AuthInfo> authInfoCache);
     }
 }

--- a/test/IntegrationTests/ContextHandlerTest.cs
+++ b/test/IntegrationTests/ContextHandlerTest.cs
@@ -59,7 +59,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             XacmlContextRequest expectedEnrichedRequest = TestSetupUtil.GetEnrichedRequest(testCase);
 
             // Act
-            XacmlContextRequest enrichedRequest = await _contextHandler.Enrich(request, false);
+            XacmlContextRequest enrichedRequest = await _contextHandler.Enrich(request, false, null);
 
             // Assert
             Assert.NotNull(enrichedRequest);
@@ -88,7 +88,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             XacmlContextRequest expectedEnrichedRequest = TestSetupUtil.GetEnrichedRequest(testCase);
 
             // Act
-            XacmlContextRequest enrichedRequest = await _contextHandler.Enrich(request, false);
+            XacmlContextRequest enrichedRequest = await _contextHandler.Enrich(request, false, null);
 
             // Assert
             Assert.NotNull(enrichedRequest);
@@ -117,7 +117,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             XacmlContextRequest expectedEnrichedRequest = TestSetupUtil.GetEnrichedRequest(testCase);
 
             // Act
-            XacmlContextRequest enrichedRequest = await _contextHandler.Enrich(request, false);
+            XacmlContextRequest enrichedRequest = await _contextHandler.Enrich(request, false, null);
 
             // Assert
             Assert.NotNull(enrichedRequest);
@@ -146,7 +146,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             XacmlContextRequest expectedEnrichedRequest = TestSetupUtil.GetEnrichedRequest(testCase);
 
             // Act
-            XacmlContextRequest enrichedRequest = await _contextHandler.Enrich(request, false);
+            XacmlContextRequest enrichedRequest = await _contextHandler.Enrich(request, false, null);
 
             // Assert
             Assert.NotNull(enrichedRequest);
@@ -175,7 +175,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             XacmlContextRequest expectedEnrichedRequest = TestSetupUtil.GetEnrichedRequest(testCase);
 
             // Act
-            XacmlContextRequest enrichedRequest = await _contextHandler.Enrich(request, false);
+            XacmlContextRequest enrichedRequest = await _contextHandler.Enrich(request, false, null);
 
             // Assert
             Assert.NotNull(enrichedRequest);
@@ -204,7 +204,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests
             XacmlContextRequest expectedEnrichedRequest = TestSetupUtil.GetEnrichedRequest(testCase);
 
             // Act
-            XacmlContextRequest enrichedRequest = await _contextHandler.Enrich(request, false);
+            XacmlContextRequest enrichedRequest = await _contextHandler.Enrich(request, false, null);
 
             // Assert
             Assert.NotNull(enrichedRequest);

--- a/test/IntegrationTests/MockServices/ContextHandlerMock.cs
+++ b/test/IntegrationTests/MockServices/ContextHandlerMock.cs
@@ -48,12 +48,12 @@ namespace Altinn.Platform.Authorization.IntegrationTests.MockServices
             _rolesWrapper = rolesWrapper;
         }
 
-        public async Task<XacmlContextRequest> Enrich(XacmlContextRequest request, bool isExternalRequest, SortedDictionary<string, AuthInfo> authInfoCache)
+        public async Task<XacmlContextRequest> Enrich(XacmlContextRequest request, bool isExternalRequest, SortedDictionary<string, AuthInfo> authInfoForOneDecReq)
         {
             string testID = GetTestId(_httpContextAccessor.HttpContext);
             if (!string.IsNullOrEmpty(testID) && testID.ToLower().Contains("altinnapps"))
             {
-                await EnrichResourceAttributes(request, authInfoCache);
+                await EnrichResourceAttributes(request, authInfoForOneDecReq);
             }
             else
             {
@@ -69,7 +69,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests.MockServices
             return request;
         }
 
-        private async Task EnrichResourceAttributes(XacmlContextRequest request, SortedDictionary<string, AuthInfo> authInfoCache)
+        private async Task EnrichResourceAttributes(XacmlContextRequest request, SortedDictionary<string, AuthInfo> authInfoForOneDecReq)
         {
             string orgAttributeValue = string.Empty;
             string appAttributeValue = string.Empty;

--- a/test/IntegrationTests/MockServices/ContextHandlerMock.cs
+++ b/test/IntegrationTests/MockServices/ContextHandlerMock.cs
@@ -48,12 +48,12 @@ namespace Altinn.Platform.Authorization.IntegrationTests.MockServices
             _rolesWrapper = rolesWrapper;
         }
 
-        public async Task<XacmlContextRequest> Enrich(XacmlContextRequest request, bool isExternalRequest)
+        public async Task<XacmlContextRequest> Enrich(XacmlContextRequest request, bool isExternalRequest, SortedDictionary<string, AuthInfo> authInfoCache)
         {
             string testID = GetTestId(_httpContextAccessor.HttpContext);
             if (!string.IsNullOrEmpty(testID) && testID.ToLower().Contains("altinnapps"))
             {
-                await EnrichResourceAttributes(request);
+                await EnrichResourceAttributes(request, authInfoCache);
             }
             else
             {
@@ -69,7 +69,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests.MockServices
             return request;
         }
 
-        private async Task EnrichResourceAttributes(XacmlContextRequest request)
+        private async Task EnrichResourceAttributes(XacmlContextRequest request, SortedDictionary<string, AuthInfo> authInfoCache)
         {
             string orgAttributeValue = string.Empty;
             string appAttributeValue = string.Empty;

--- a/test/IntegrationTests/MockServices/ContextHandlerMock.cs
+++ b/test/IntegrationTests/MockServices/ContextHandlerMock.cs
@@ -48,12 +48,12 @@ namespace Altinn.Platform.Authorization.IntegrationTests.MockServices
             _rolesWrapper = rolesWrapper;
         }
 
-        public async Task<XacmlContextRequest> Enrich(XacmlContextRequest request, bool isExternalRequest, SortedDictionary<string, AuthInfo> authInfoForOneDecReq)
+        public async Task<XacmlContextRequest> Enrich(XacmlContextRequest request, bool isExternalRequest, SortedDictionary<string, AuthInfo> appInstanceInfo)
         {
             string testID = GetTestId(_httpContextAccessor.HttpContext);
             if (!string.IsNullOrEmpty(testID) && testID.ToLower().Contains("altinnapps"))
             {
-                await EnrichResourceAttributes(request, authInfoForOneDecReq);
+                await EnrichResourceAttributes(request, appInstanceInfo);
             }
             else
             {
@@ -69,7 +69,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests.MockServices
             return request;
         }
 
-        private async Task EnrichResourceAttributes(XacmlContextRequest request, SortedDictionary<string, AuthInfo> authInfoForOneDecReq)
+        private async Task EnrichResourceAttributes(XacmlContextRequest request, SortedDictionary<string, AuthInfo> appInstanceInfo)
         {
             string orgAttributeValue = string.Empty;
             string appAttributeValue = string.Empty;


### PR DESCRIPTION
Avoid redundant auth info calls for different actions within the same resource