### PR TITLE
Internal decision requests failing when duplicate subject IDs on request

### DIFF
--- a/src/Authorization/Services/Implementation/ContextHandler.cs
+++ b/src/Authorization/Services/Implementation/ContextHandler.cs
@@ -370,7 +370,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                 throw new ArgumentException("Not allowed to set userid and person-id for subject at the same time");
             }
 
-            if (!string.IsNullOrEmpty(subjectOrgnNo) && (subjectUserId != 0 || !string.IsNullOrEmpty(subjectSsn)))
+            if (isExternalRequest && !string.IsNullOrEmpty(subjectOrgnNo) && (subjectUserId != 0 || !string.IsNullOrEmpty(subjectSsn)))
             {
                 throw new ArgumentException("Not allowed to set organization number and person-id or userid for subject at the same time");
             }
@@ -390,7 +390,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                 }
             }
 
-            if (!string.IsNullOrEmpty(subjectOrgnNo))
+            if (isExternalRequest && !string.IsNullOrEmpty(subjectOrgnNo))
             {
                 int partyId = await _registerService.PartyLookup(subjectOrgnNo, null);
                 subjectContextAttributes.Attributes.Add(GetPartyIdsAttribute(new List<int> { partyId }));


### PR DESCRIPTION
## Description
PR 846 Fixes for external Authorize API introduced an ArgumentException if providing multiple subject identifiers (organization number, user id and person id) together, which was meant for external requests to the Authorize API endpoint.

This however also triggers for internal Decision API, and breaks existing authorization requests for enterprise users where both user id and organization number are present on the requests from the PEP.

This change does the following to mitigate this issue:
1. The multiple subject identifiers argument only triggered for external Authorize API endpoint
2. Setting PartyId based on organization number, also moved to only be enriched for external Authorize API. This means only external authorize requests will be able to authorize organizations through delegations.
3. For Authorize API endpoint ArgumentException error messages are added to the XacmlContextStatus response as ProcessingError

## Related Issue(s)
- #844

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
