### PR TITLE
Update port to 5050 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN dotnet build Altinn.Platform.Authorization.csproj -c Release -o /app_output
 RUN dotnet publish Altinn.Platform.Authorization.csproj -c Release -o /app_output
 
 FROM mcr.microsoft.com/dotnet/aspnet:8.0.4-alpine3.18 AS final
-EXPOSE 5030
+EXPOSE 5050
 WORKDIR /app
 COPY --from=build /app_output .
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Seems a copy/paste error from profile that has followed us for years. 
Port used for authorization is 5050 and not 5030. 

## Related Issue(s)
- #N/A