### PR TITLE
made changes to prevent 401 responsesn in pipeline testruns

### DIFF
--- a/test/Bruno/Altinn.Authorization/Automatic Test Collection/Authorization/1 GET parties.bru
+++ b/test/Bruno/Altinn.Authorization/Automatic Test Collection/Authorization/1 GET parties.bru
@@ -7,7 +7,7 @@ meta {
 get {
   url: {{baseUrl}}/authorization/api/v1/parties?userId={{auth_userId}}
   body: none
-  auth: none
+  auth: inherit
 }
 
 headers {

--- a/test/Bruno/Altinn.Authorization/Automatic Test Collection/Authorization/2 GET Roles.bru
+++ b/test/Bruno/Altinn.Authorization/Automatic Test Collection/Authorization/2 GET Roles.bru
@@ -7,7 +7,7 @@ meta {
 get {
   url: {{baseUrl}}/authorization/api/v1/roles?coveredbyuserid={{auth_userId}}&offeredbypartyid={{auth_partyId}}
   body: none
-  auth: none
+  auth: inherit
 }
 
 headers {

--- a/test/Bruno/Altinn.Authorization/Automatic Test Collection/Authorization/3 POST Decision result on read is permit.bru
+++ b/test/Bruno/Altinn.Authorization/Automatic Test Collection/Authorization/3 POST Decision result on read is permit.bru
@@ -7,7 +7,7 @@ meta {
 post {
   url: {{baseUrl}}/authorization/api/v1/decision
   body: json
-  auth: none
+  auth: inherit
 }
 
 headers {
@@ -81,8 +81,6 @@ script:pre-request {
   bru.setVar("auth_ssn", testdata.org1.dagl.pid);
   bru.setVar("party", testdata.org1.partyid);
   bru.setVar("appsAccessKey", bru.getEnvVar("appsAccessKey"));
-  
-  await testTokenGenerator.getToken();
 }
 
 script:post-response {

--- a/test/Bruno/Altinn.Authorization/Automatic Test Collection/Authorization/4 POST Decision result on sign is NotApplicable.bru
+++ b/test/Bruno/Altinn.Authorization/Automatic Test Collection/Authorization/4 POST Decision result on sign is NotApplicable.bru
@@ -7,7 +7,7 @@ meta {
 post {
   url: {{baseUrl}}/authorization/api/v1/decision
   body: json
-  auth: none
+  auth: inherit
 }
 
 headers {
@@ -81,8 +81,6 @@ script:pre-request {
   bru.setVar("auth_ssn", testdata.org1.dagl.pid);
   bru.setVar("party", testdata.org1.partyid);
   bru.setVar("appsAccessKey", bru.getEnvVar("appsAccessKey"));
-  
-  await testTokenGenerator.getToken();
 }
 
 script:post-response {

--- a/test/Bruno/Altinn.Authorization/Automatic Test Collection/Authorization/5 POST Decision result on read for task is Permit.bru
+++ b/test/Bruno/Altinn.Authorization/Automatic Test Collection/Authorization/5 POST Decision result on read for task is Permit.bru
@@ -7,7 +7,7 @@ meta {
 post {
   url: {{baseUrl}}/authorization/api/v1/decision
   body: json
-  auth: none
+  auth: inherit
 }
 
 headers {
@@ -89,8 +89,6 @@ script:pre-request {
   bru.setVar("auth_ssn", testdata.org1.dagl.pid);
   bru.setVar("party", testdata.org1.partyid);
   bru.setVar("appsAccessKey", bru.getEnvVar("appsAccessKey"));
-  
-  await testTokenGenerator.getToken();
 }
 
 script:post-response {

--- a/test/Bruno/Altinn.Authorization/Automatic Test Collection/Authorization/6 POST Decision result on read for events is Permit.bru
+++ b/test/Bruno/Altinn.Authorization/Automatic Test Collection/Authorization/6 POST Decision result on read for events is Permit.bru
@@ -7,7 +7,7 @@ meta {
 post {
   url: {{baseUrl}}/authorization/api/v1/decision
   body: json
-  auth: none
+  auth: inherit
 }
 
 headers {
@@ -89,8 +89,6 @@ script:pre-request {
   bru.setVar("auth_ssn", testdata.org1.dagl.pid);
   bru.setVar("party", testdata.org1.partyid);
   bru.setVar("appsAccessKey", bru.getEnvVar("appsAccessKey"));
-  
-  await testTokenGenerator.getToken();
 }
 
 script:post-response {


### PR DESCRIPTION
## Description
-changed auth:none to auth:inherit on tests to prevent 401 response in pipeline
-tests that don't use tokens no longer generate them

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
