### PR TITLE
fixed failing tests after bruno update

### DIFF
--- a/test/Bruno/Altinn.Authorization/Automatic Test Collection/Authorization/1 GET parties.bru
+++ b/test/Bruno/Altinn.Authorization/Automatic Test Collection/Authorization/1 GET parties.bru
@@ -39,7 +39,7 @@ script:pre-request {
   bru.setVar("to_partyid", testdata.org2.partyid);
   bru.setVar("appsAccessKey", bru.getEnvVar("appsAccessKey"));
   
-  await testTokenGenerator.getToken();
+  bru.setVar("bearerToken", await testTokenGenerator.getToken("altinn:instances.read"));
 }
 
 script:post-response {

--- a/test/Bruno/Altinn.Authorization/Automatic Test Collection/Authorization/2 GET Roles.bru
+++ b/test/Bruno/Altinn.Authorization/Automatic Test Collection/Authorization/2 GET Roles.bru
@@ -39,7 +39,7 @@ script:pre-request {
   bru.setVar("party", testdata.org1.partyid);
   bru.setVar("appsAccessKey", bru.getEnvVar("appsAccessKey"));
   
-  await testTokenGenerator.getToken();
+  bru.setVar("bearerToken", await testTokenGenerator.getToken("altinn:instances.read"));
 }
 
 script:post-response {

--- a/test/Bruno/Altinn.Authorization/Automatic Test Collection/Authorization/3 POST Decision result on read is permit.bru
+++ b/test/Bruno/Altinn.Authorization/Automatic Test Collection/Authorization/3 POST Decision result on read is permit.bru
@@ -82,7 +82,7 @@ script:pre-request {
   bru.setVar("party", testdata.org1.partyid);
   bru.setVar("appsAccessKey", bru.getEnvVar("appsAccessKey"));
   
-  await testTokenGenerator.getToken();
+  bru.setVar("bearerToken", await testTokenGenerator.getToken("altinn:instances.read"));
 }
 
 script:post-response {

--- a/test/Bruno/Altinn.Authorization/Automatic Test Collection/Authorization/4 POST Decision result on sign is NotApplicable.bru
+++ b/test/Bruno/Altinn.Authorization/Automatic Test Collection/Authorization/4 POST Decision result on sign is NotApplicable.bru
@@ -82,7 +82,7 @@ script:pre-request {
   bru.setVar("party", testdata.org1.partyid);
   bru.setVar("appsAccessKey", bru.getEnvVar("appsAccessKey"));
   
-  await testTokenGenerator.getToken();
+  bru.setVar("bearerToken", await testTokenGenerator.getToken("altinn:instances.read"));
 }
 
 script:post-response {

--- a/test/Bruno/Altinn.Authorization/Automatic Test Collection/Authorization/5 POST Decision result on read for task is Permit.bru
+++ b/test/Bruno/Altinn.Authorization/Automatic Test Collection/Authorization/5 POST Decision result on read for task is Permit.bru
@@ -90,7 +90,7 @@ script:pre-request {
   bru.setVar("party", testdata.org1.partyid);
   bru.setVar("appsAccessKey", bru.getEnvVar("appsAccessKey"));
   
-  await testTokenGenerator.getToken();
+  bru.setVar("bearerToken", await testTokenGenerator.getToken("altinn:instances.read"));
 }
 
 script:post-response {

--- a/test/Bruno/Altinn.Authorization/Automatic Test Collection/Authorization/6 POST Decision result on read for events is Permit.bru
+++ b/test/Bruno/Altinn.Authorization/Automatic Test Collection/Authorization/6 POST Decision result on read for events is Permit.bru
@@ -90,7 +90,7 @@ script:pre-request {
   bru.setVar("party", testdata.org1.partyid);
   bru.setVar("appsAccessKey", bru.getEnvVar("appsAccessKey"));
   
-  await testTokenGenerator.getToken();
+  bru.setVar("bearerToken", await testTokenGenerator.getToken("altinn:instances.read"));
 }
 
 script:post-response {

--- a/test/Bruno/Altinn.Authorization/TestTokenGenerator.js
+++ b/test/Bruno/Altinn.Authorization/TestTokenGenerator.js
@@ -1,5 +1,5 @@
 
-exports.getToken = async function () {
+exports.getToken = async function (scopes) {
   const axios = require("axios");
   const btoa = require("btoa");
 
@@ -13,7 +13,7 @@ exports.getToken = async function () {
   const tokenUser = bru.getVar("auth_userId");
   const tokenParty = bru.getVar("auth_partyId");
   const tokenPid = bru.getVar("auth_ssn");
-  const tokenScopes = bru.getVar("auth_scopes");
+  const tokenScopes = scopes;
   const tokenOrg = bru.getVar("auth_org");
   const tokenOrgNo = bru.getVar("auth_orgNo");
   const tokenUsername = bru.getVar("auth_username");
@@ -35,5 +35,5 @@ exports.getToken = async function () {
     headers: { Authorization }
   });
 
-  bru.setVar("bearerToken", response.data);
+  return response.data;
 }


### PR DESCRIPTION
## Description
A Bruno updated made variables scoped within a request inaccessible from outside of it, which caused tests to fail. TestToolTokenGenerator has been updated to work with this new change.

## Related Issue(s)
- #956 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
