### PR TITLE
Broken PostgreSQL functions for replay of delegation change events

### DIFF
--- a/src/Authorization/Migration/v0.08/01-setup-procedures.sql
+++ b/src/Authorization/Migration/v0.08/01-setup-procedures.sql
@@ -44,7 +44,17 @@ CREATE OR REPLACE FUNCTION delegation.get_current_change(
 	_offeredbypartyid integer,
 	_coveredbyuserid integer,
 	_coveredbypartyid integer)
-    RETURNS SETOF delegation.delegationchanges 
+    RETURNS TABLE(
+        delegationchangeid integer,
+        delegationchangetype delegation.delegationchangetype,
+        altinnappid text,
+        offeredbypartyid integer,
+        coveredbypartyid integer,
+        coveredbyuserid integer,
+        performedbyuserid integer,
+        blobstoragepolicypath text,
+        blobstorageversionid text,
+        created timestamp with time zone)
     LANGUAGE 'sql'
     COST 100
     STABLE PARALLEL SAFE 

--- a/src/Authorization/Migration/v0.09/01-setup-procedures.sql
+++ b/src/Authorization/Migration/v0.09/01-setup-procedures.sql
@@ -1,4 +1,5 @@
--- Function: select_delegationchanges_by_id_range
+-- Function: select_delegationchanges_by_id_range 
+-- Broken PostgreSQL functions for replay of delegation change events #1069
 DROP FUNCTION IF EXISTS delegation.select_delegationchanges_by_id_range(bigint, bigint);
 
 CREATE OR REPLACE FUNCTION delegation.select_delegationchanges_by_id_range(
@@ -27,8 +28,8 @@ AS $BODY$
     delegationChangeType,
     altinnAppId, 
     offeredByPartyId,
-    coveredByUserId,
     coveredByPartyId,
+    coveredByUserId,    
     performedByUserId,
     blobStoragePolicyPath,
     blobStorageVersionId,

--- a/src/Authorization/Migration/v0.09/01-setup-procedures.sql
+++ b/src/Authorization/Migration/v0.09/01-setup-procedures.sql
@@ -1,4 +1,5 @@
--- Function: select_delegationchanges_by_id_range
+-- Function: select_delegationchanges_by_id_range 
+-- Broken PostgreSQL functions for replay of delegation change events #1069
 DROP FUNCTION IF EXISTS delegation.select_delegationchanges_by_id_range(bigint, bigint);
 
 CREATE OR REPLACE FUNCTION delegation.select_delegationchanges_by_id_range(

--- a/src/Authorization/Migration/v0.09/01-setup-procedures.sql
+++ b/src/Authorization/Migration/v0.09/01-setup-procedures.sql
@@ -1,5 +1,4 @@
--- Function: select_delegationchanges_by_id_range 
--- Broken PostgreSQL functions for replay of delegation change events #1069
+-- Function: select_delegationchanges_by_id_range
 DROP FUNCTION IF EXISTS delegation.select_delegationchanges_by_id_range(bigint, bigint);
 
 CREATE OR REPLACE FUNCTION delegation.select_delegationchanges_by_id_range(


### PR DESCRIPTION
## Description

The PostgreSQL functions used from the Azure function app for replay of delegation change events is currently broken after the recent database changes which have added additional columns to the delegationchange table.

The functions have been updated from using the table definition as return type to use a temp table definition for the relevant columns (as already done in one of the functions in the v0.08 script):

- Updated old Migration scripts v0.07 & v0.08 so that they no longer fail on setup for a clean db installation
- Created new Migration script v0.09 (copy of the fixed v0.08) to update existing deployed functions

## Related Issue(s)
- #1069 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
