### PR TITLE
Fix for wrong order of parameters to HttpClient.GetAsync

### DIFF
--- a/src/Authorization/Services/Implementation/RegisterService.cs
+++ b/src/Authorization/Services/Implementation/RegisterService.cs
@@ -65,7 +65,7 @@ namespace Altinn.Platform.Authorization.Services
                 string token = JwtTokenUtil.GetTokenFromContext(_httpContextAccessor.HttpContext, _generalSettings.RuntimeCookieName);
                 string accessToken = _accessTokenGenerator.GenerateAccessToken("platform", "authorization");
 
-                HttpResponseMessage response = await _client.GetAsync(token, endpointUrl, accessToken);
+                HttpResponseMessage response = await _client.GetAsync(endpointUrl, token, accessToken);
 
                 if (response.StatusCode == HttpStatusCode.OK)
                 {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fix for wrong order of parameters to HttpClient.GetAsync

## Related Issue(s)
#748
#751

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
