### PR TITLE
Add overload for CreateDecisionRequest where instanceOwnerId, instanceGuid and taskId is omitted

### DIFF
--- a/src/Altinn.Common.PEP/Altinn.Common.PEP/Helpers/DecisionHelper.cs
+++ b/src/Altinn.Common.PEP/Altinn.Common.PEP/Helpers/DecisionHelper.cs
@@ -67,6 +67,30 @@ namespace Altinn.Common.PEP.Helpers
         }
 
         /// <summary>
+        /// Create decision request based for policy decision point.
+        /// </summary>
+        /// <param name="org">Unique identifier of the organisation responsible for the app.</param>
+        /// <param name="app">Application identifier which is unique within an organisation.</param>
+        /// <param name="user">Claims principal user.</param>
+        /// <param name="actionType">Policy action type i.e. read, write, delete, instantiate.</param>
+        /// <returns>The decision request.</returns>
+        public static XacmlJsonRequestRoot CreateDecisionRequest(string org, string app, ClaimsPrincipal user, string actionType)
+        {
+            XacmlJsonRequest request = new XacmlJsonRequest();
+            request.AccessSubject = new List<XacmlJsonCategory>();
+            request.Action = new List<XacmlJsonCategory>();
+            request.Resource = new List<XacmlJsonCategory>();
+
+            request.AccessSubject.Add(CreateSubjectCategory(user.Claims));
+            request.Action.Add(CreateActionCategory(actionType));
+            request.Resource.Add(CreateResourceCategory(org, app, null, null, null));
+
+            XacmlJsonRequestRoot jsonRequest = new XacmlJsonRequestRoot() { Request = request };
+
+            return jsonRequest;
+        }
+
+        /// <summary>
         /// Create a new <see cref="XacmlJsonRequestRoot"/> to represent a decision request.
         /// </summary>
         /// <param name="context">The current <see cref="AuthorizationHandlerContext"/></param>

--- a/src/Altinn.Common.PEP/UnitTests/DecisionHelperTest.cs
+++ b/src/Altinn.Common.PEP/UnitTests/DecisionHelperTest.cs
@@ -61,6 +61,57 @@ namespace UnitTests
         public void CreateXacmlJsonRequest_TC03()
         {
             // Arrange & Act
+            XacmlJsonRequestRoot requestRoot = DecisionHelper.CreateDecisionRequest(Org, App, CreateMaskinportenClaims("12313", "altinn.master"), ActionType);
+            XacmlJsonRequest request = requestRoot.Request;
+
+            // Assert
+            Assert.Equal(4, request.AccessSubject[0].Attribute.Count);
+            Assert.Single(request.Action[0].Attribute);
+            Assert.Equal(2, request.Resource[0].Attribute.Count);
+        }
+        
+        /// <summary>
+        /// Test case: Send attributes and creates request out of it 
+        /// Expected: All values sent in will be created to attributes
+        /// </summary>
+        [Fact]
+        public void CreateXacmlJsonRequest_TC04()
+        {
+            // Arrange & Act
+            XacmlJsonRequestRoot requestRoot = DecisionHelper.CreateDecisionRequest(Org, App, CreateUserClaims(false), ActionType);
+            XacmlJsonRequest request = requestRoot.Request;
+
+            // Assert
+            Assert.Equal(2, request.AccessSubject[0].Attribute.Count);
+            Assert.Single(request.Action[0].Attribute);
+            Assert.Equal(2, request.Resource[0].Attribute.Count);
+        }
+
+        /// <summary>
+        /// Test case: Send attributes and creates request out of it 
+        /// Expected: Only valid urn values sent in will be created to attributes
+        /// </summary>
+        [Fact]
+        public void CreateXacmlJsonRequest_TC05()
+        {
+            // Arrange & Act
+            XacmlJsonRequestRoot requestRoot = DecisionHelper.CreateDecisionRequest(Org, App, CreateUserClaims(true), ActionType);
+            XacmlJsonRequest request = requestRoot.Request;
+
+            // Assert
+            Assert.Equal(2, request.AccessSubject[0].Attribute.Count);
+            Assert.Single(request.Action[0].Attribute);
+            Assert.Equal(2, request.Resource[0].Attribute.Count);
+        }
+
+        /// <summary>
+        /// Test case: Send attributes and creates request out of it 
+        /// Expected: Only valid urn, scope and orgnumber with correct values sent in will be created to attributes
+        /// </summary>
+        [Fact]
+        public void CreateXacmlJsonRequest_TC06()
+        {
+            // Arrange & Act
             XacmlJsonRequestRoot requestRoot = DecisionHelper.CreateDecisionRequest(Org, App, CreateMaskinportenClaims("12313", "altinn.master"), ActionType, PartyId, null, null);
             XacmlJsonRequest request = requestRoot.Request;
 


### PR DESCRIPTION
## Description
When making a request to storage to get active instances for a certain app, we want to be able to use the policy.xml file to authorize a request. The specific use cases is for the project Digital gravferd which uses these types of requests on behalf of the organisation ` digdir` whereas the service owner of the apps the requests are relevant for, is `sfvt`. In such a case, we have no `instanceOwnerPartyId` as a resource for the decision, and we need to be able to create a decision request without `instanceOwnerPartyId`.

The need for this overload occurred in [this pr](https://github.com/Altinn/altinn-storage/pull/564) of altinn-storage. 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

