### PR TITLE
UserProfile Cache improvement

### DIFF
--- a/src/Authorization/Services/Implementation/DelegationContextHandler.cs
+++ b/src/Authorization/Services/Implementation/DelegationContextHandler.cs
@@ -56,7 +56,7 @@ namespace Altinn.Platform.Authorization.Services.Implementation
                 if (isInstanceAccessRequest)
                 {
                     // Instance delegation policies use uuid as subject, meaning the request needs to be enriched with the users uuid
-                    UserProfile userProfile = await _profileWrapper.GetUserProfile(subjectUserId, cancellationToken);
+                    UserProfile userProfile = await GetUserProfileByUserId(subjectUserId, cancellationToken);
                     if (userProfile != null && userProfile.Party != null &&
                         userProfile.Party.PartyTypeName == PartyType.Person && userProfile.Party.PartyUuid.HasValue)
                     {

--- a/test/IntegrationTests/Data/Xacml/3.0/ResourceRegistry/AltinnResourceRegistryMulti0012Request.json
+++ b/test/IntegrationTests/Data/Xacml/3.0/ResourceRegistry/AltinnResourceRegistryMulti0012Request.json
@@ -10,6 +10,15 @@
             "Value": "01039012345"
           }
         ]
+      },
+      {
+        "Id": "s2",
+        "Attribute": [
+          {
+            "AttributeId": "urn:altinn:userid",
+            "Value": "1337"
+          }
+        ]
       }
     ],
     "Action": [
@@ -70,6 +79,26 @@
             "IncludeInResult": true
           }
         ]
+      },
+      {
+        "Id": "r4",
+        "Attribute": [
+          {
+            "AttributeId": "urn:altinn:resource",
+            "Value": "ttd-externalpdp-resource3",
+            "IncludeInResult": true
+          },
+          {
+            "AttributeId": "urn:altinn:resource:instance-id",
+            "Value": "4c1b880e-f425-4050-9a46-cd1b3e56bf94",
+            "IncludeInResult": true
+          },
+          {
+            "AttributeId": "urn:altinn:organization:identifier-no",
+            "Value": "910459880",
+            "IncludeInResult": true
+          }
+        ]
       }
     ],
     "MultiRequests": {
@@ -93,6 +122,13 @@
             "s1",
             "a1",
             "r3"
+          ]
+        },
+        {
+          "ReferenceId": [
+            "s2",
+            "a1",
+            "r4"
           ]
         }
       ]

--- a/test/IntegrationTests/Data/Xacml/3.0/ResourceRegistry/AltinnResourceRegistryMulti0012Response.json
+++ b/test/IntegrationTests/Data/Xacml/3.0/ResourceRegistry/AltinnResourceRegistryMulti0012Response.json
@@ -135,6 +135,46 @@
         }
 
       ]
+    },
+    {
+      "Decision": "NotApplicable",
+      "Status": {
+        "StatusCode": {
+          "Value": "urn:oasis:names:tc:xacml:1.0:status:ok"
+        }
+      },
+      "Category": [
+        {
+          "CategoryId": "urn:oasis:names:tc:xacml:3.0:attribute-category:action",
+          "Attribute": [
+            {
+              "AttributeId": "urn:oasis:names:tc:xacml:1.0:action:action-id",
+              "DataType": "http://www.w3.org/2001/XMLSchema#string",
+              "Value": "read"
+            }
+          ]
+        },
+        {
+          "CategoryId": "urn:oasis:names:tc:xacml:3.0:attribute-category:resource",
+          "Attribute": [
+            {
+              "AttributeId": "urn:altinn:resource",
+              "DataType": "http://www.w3.org/2001/XMLSchema#string",
+              "Value": "ttd-externalpdp-resource3"
+            },
+            {
+              "AttributeId": "urn:altinn:resource:instance-id",
+              "DataType": "http://www.w3.org/2001/XMLSchema#string",
+              "Value": "4c1b880e-f425-4050-9a46-cd1b3e56bf94"
+            },
+            {
+              "AttributeId": "urn:altinn:organization:identifier-no",
+              "DataType": "http://www.w3.org/2001/XMLSchema#string",
+              "Value": "910459880"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/test/IntegrationTests/MockServices/AccessManagementWrapperMock.cs
+++ b/test/IntegrationTests/MockServices/AccessManagementWrapperMock.cs
@@ -70,6 +70,9 @@ public class AccessManagementWrapperMock : IAccessManagementWrapper
                 DelegationChangesTestData.Default(DelegationChangesTestData.WithResourceID("app_org1_app1"), DelegationChangesTestData.WithResourceInstanceId("f8d3526c-596b-4322-a041-38a8925c2a82"), DelegationChangesTestData.WithFromUuid(UuidType.Organization, Guid.Parse("00000000-0000-0000-0005-000000005545")), DelegationChangesTestData.WithToUuid(UuidType.Organization, Guid.Parse("00000000-0000-0000-0005-000000004222"))),
                 WithDefaultCondition("org1/app1", new AttributeMatch { Id = XacmlRequestAttribute.PartyAttribute, Value = "50005545" }, new AttributeMatch { Id = XacmlRequestAttribute.PartyAttribute, Value = "50004222" }),
                 WithDefaultCondition("org1/app1", new AttributeMatch { Id = XacmlRequestAttribute.PartyAttribute, Value = "50005545" }, new AttributeMatch { Id = XacmlRequestAttribute.UserAttribute, Value = "20000095" })),
+            ConditionalAdd(
+                DelegationChangesTestData.Default(DelegationChangesTestData.WithResourceID("ttd-externalpdp-resource3"), DelegationChangesTestData.WithResourceInstanceId("4c1b880e-f425-4050-9a46-cd1b3e56bf94"), DelegationChangesTestData.WithOfferedByPartyID(50005545), DelegationChangesTestData.WithCoveredByUserID(1337)),
+                WithDefaultCondition("ttd-externalpdp-resource3", new AttributeMatch { Id = XacmlRequestAttribute.PartyAttribute, Value = "50005545" }, new AttributeMatch { Id = XacmlRequestAttribute.UserAttribute, Value = "1337" })),
         };
 
         var result = new List<DelegationChangeExternal>();

--- a/test/IntegrationTests/MockServices/ProfileMock.cs
+++ b/test/IntegrationTests/MockServices/ProfileMock.cs
@@ -16,9 +16,13 @@ namespace Altinn.Platform.Authorization.IntegrationTests.MockServices
             {
                 userProfile = new UserProfile { Party = new Party { SSN = "13923949741" } };
             }
+            else if (userId == 13371337)
+            {
+                userProfile = new UserProfile { UserId = userId, Party = new Party { SSN = "13371337133" } };
+            }
             else if (userId == 1337)
             {
-                userProfile = new UserProfile { Party = new Party { SSN = "13371337133" } };
+                userProfile = new UserProfile { UserId = userId, Party = new Party { SSN = "01039012345", PartyId = 1337, PartyUuid = Guid.Parse("00000000-0000-0000-0005-000000001337"), PartyTypeName = Register.Enums.PartyType.Person } };
             }
             else if (userId == 20000517)
             {
@@ -41,7 +45,7 @@ namespace Altinn.Platform.Authorization.IntegrationTests.MockServices
             }
             else if (personId == "13371337133")
             {
-                userProfile = new UserProfile { Party = new Party { SSN = personId } };
+                userProfile = new UserProfile { UserId = 13371337, Party = new Party { SSN = personId } };
             }
             else if (personId == "01039012345")
             {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- UserProfile lookups are now cached on both UserId and PersonId (SSN)
- DelegationContextHandler now use the same cached implementation from ContextHandler base class

## Related Issue(s)
- #1222

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
