### PR TITLE
PEP | Fix correct resource-instance and person-identifier urns

### DIFF
--- a/src/Altinn.Common.PEP/Altinn.Common.PEP/Altinn.Common.PEP.csproj
+++ b/src/Altinn.Common.PEP/Altinn.Common.PEP/Altinn.Common.PEP.csproj
@@ -8,7 +8,7 @@
     <IsPackable>true</IsPackable>
     <!-- NuGet package properties -->
     <PackageId>Altinn.Common.PEP</PackageId>
-    <Version>4.1.2</Version>
+    <Version>4.1.3</Version>
     <PackageTags>Altinn;Studio;Authorization;Policy;Enforcement;Point</PackageTags>
     <Description>
 		Policy Enforcement Point for Attribute-based authorization using Altinn.Authorization.ABAC in ASP.Net apps.
@@ -27,7 +27,8 @@
   <ItemGroup>
     <PackageReference Include="Altinn.Authorization.ABAC" Version="0.0.8" />
     <!-- More about this dependency in issue #5706 -->
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.35" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="8.0.13" />
+    <PackageReference Include="System.Text.Json" Version="9.0.2" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(Configuration)'=='Debug'">

--- a/src/Altinn.Common.PEP/Altinn.Common.PEP/Constants/AltinnXacmlUrns.cs
+++ b/src/Altinn.Common.PEP/Altinn.Common.PEP/Constants/AltinnXacmlUrns.cs
@@ -11,9 +11,9 @@ namespace Altinn.Common.PEP.Constants
         public const string PartyId = "urn:altinn:partyid";
 
         /// <summary>
-        /// Get the URN value for 
+        /// Get the URN value for person. Only supported for use in external Authorize API
         /// </summary>
-        public const string Ssn = "urn:altinn:ssn";
+        public const string PersonId = "urn:altinn:person:identifier-no";
 
         /// <summary>
         /// Get the URN value for organization number. This is the legacy version 
@@ -63,7 +63,7 @@ namespace Altinn.Common.PEP.Constants
         /// <summary>
         /// Get the value Resource Instance
         /// </summary>
-        public const string ResourceInstance = "urn:altinn:resourceinstance";
+        public const string ResourceInstance = "urn:altinn:resource:instance-id";
 
         /// <summary>
         /// Get the value eventType
@@ -99,10 +99,5 @@ namespace Altinn.Common.PEP.Constants
         /// xacml string that represents person universally unique identifier
         /// </summary>
         public const string PersonUuidAttribute = "urn:altinn:person:uuid";
-
-        /// <summary>
-        /// xacml string that represents party
-        /// </summary>
-        public const string PartyAttribute = "urn:altinn:partyid";
     }
 }

--- a/src/Altinn.Common.PEP/Altinn.Common.PEP/Helpers/DecisionHelper.cs
+++ b/src/Altinn.Common.PEP/Altinn.Common.PEP/Helpers/DecisionHelper.cs
@@ -237,7 +237,7 @@ namespace Altinn.Common.PEP.Helpers
                 }
                 else if (IsPartyIdClaim(claim.Type))
                 {
-                    partyIdAttribute = CreateXacmlJsonAttribute(AltinnXacmlUrns.PartyAttribute, claim.Value, DefaultType, claim.Issuer);
+                    partyIdAttribute = CreateXacmlJsonAttribute(AltinnXacmlUrns.PartyId, claim.Value, DefaultType, claim.Issuer);
                 }
                 else if (IsResourceClaim(claim.Type))
                 {
@@ -340,7 +340,7 @@ namespace Altinn.Common.PEP.Helpers
             }
             else if (!string.IsNullOrEmpty(ssn))
             {
-                resourceCategory.Attribute.Add(CreateXacmlJsonAttribute(AltinnXacmlUrns.Ssn, ssn, DefaultType, DefaultIssuer, includeResult));
+                resourceCategory.Attribute.Add(CreateXacmlJsonAttribute(AltinnXacmlUrns.PersonId, ssn, DefaultType, DefaultIssuer, includeResult));
             }
 
             if (!string.IsNullOrWhiteSpace(resourceid))
@@ -400,7 +400,7 @@ namespace Altinn.Common.PEP.Helpers
 
         private static bool IsPartyIdClaim(string name)
         {
-            return name.Equals(AltinnXacmlUrns.PartyAttribute);
+            return name.Equals(AltinnXacmlUrns.PartyId);
         }
 
         private static bool IsResourceClaim(string name)

--- a/src/Altinn.Common.PEP/UnitTests/ResourceAccessHandlerTest.cs
+++ b/src/Altinn.Common.PEP/UnitTests/ResourceAccessHandlerTest.cs
@@ -123,7 +123,7 @@ namespace Altinn.Common.PEP.Authorization
             Assert.False(context.HasFailed);
 
             XacmlJsonRequestRoot request = _pdpMock.Invocations[0].Arguments[0] as XacmlJsonRequestRoot;
-            Assert.Equal("urn:altinn:ssn", request.Request.Resource[0].Attribute[0].AttributeId);
+            Assert.Equal("urn:altinn:person:identifier-no", request.Request.Resource[0].Attribute[0].AttributeId);
             Assert.Equal("01014922047", request.Request.Resource[0].Attribute[0].Value);
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updated from -> to:

- urn:altinn:resourceinstance -> urn:altinn:resource:instance-id
- urn:altinn:ssn -> urn:altinn:person:identifier-no

## Related Issue(s)
- #[authz-tmp-371](https://github.com/Altinn/altinn-authorization-tmp/pull/371)

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
